### PR TITLE
feat: use static buffer, context for cancellation, and functional arguments

### DIFF
--- a/cmd/expose.go
+++ b/cmd/expose.go
@@ -38,7 +38,7 @@ ktunnel expose redis 6379
 		// Create service and deployment
 		svcName, ports := args[0], args[1:]
 		readyChan := make(chan bool, 1)
-		err := k8s.ExposeAsService(&Namespace, &svcName, Port, Scheme, ports, readyChan)
+		err := k8s.ExposeAsService(&Namespace, &svcName, Port, Scheme, ports, ServerImage, readyChan)
 		if err != nil {
 			log.Fatalf("Failed to expose local machine as a service: %v", err)
 		}
@@ -97,5 +97,6 @@ func init() {
 	exposeCmd.Flags().StringVarP(&Scheme, "scheme", "s", "tcp", "Connection scheme")
 	exposeCmd.Flags().StringVarP(&ServerHostOverride, "server-host-override", "o", "", "Server name use to verify the hostname returned by the TLS handshake")
 	exposeCmd.Flags().StringVarP(&Namespace, "namespace", "n", "default", "Namespace")
+	exposeCmd.Flags().StringVarP(&ServerImage, "server-image", "i", k8s.Image, "Ktunnel server image to use")
 	rootCmd.AddCommand(exposeCmd)
 }

--- a/cmd/inject.go
+++ b/cmd/inject.go
@@ -15,6 +15,7 @@ import (
 )
 
 var Namespace string
+var ServerImage string
 
 var injectCmd = &cobra.Command{
 	Use:   "inject",
@@ -41,7 +42,7 @@ ktunnel inject deploymeny mydeployment 3306 6379
 		// Inject
 		deployment := args[0]
 		readyChan := make(chan bool, 1)
-		_, err := k8s.InjectSidecar(&Namespace, &deployment, &Port, readyChan)
+		_, err := k8s.InjectSidecar(&Namespace, &deployment, &Port, ServerImage, readyChan)
 		if err != nil {
 			log.Fatalf("failed injecting sidecar: %v", err)
 		}
@@ -59,7 +60,7 @@ ktunnel inject deploymeny mydeployment 3306 6379
 				cancel()
 				wg.Wait()
 				readyChan = make(chan bool, 1)
-				ok, err := k8s.RemoveSidecar(&Namespace, &deployment, readyChan)
+				ok, err := k8s.RemoveSidecar(&Namespace, &deployment, ServerImage, readyChan)
 				if !ok {
 					log.Errorf("Failed removing tunnel sidecar; %v", err)
 				}
@@ -106,6 +107,7 @@ func init() {
 	injectDeploymentCmd.Flags().StringVarP(&Scheme, "scheme", "s", "tcp", "Connection scheme")
 	injectDeploymentCmd.Flags().StringVarP(&ServerHostOverride, "server-host-override", "o", "", "Server name use to verify the hostname returned by the TLS handshake")
 	injectDeploymentCmd.Flags().StringVarP(&Namespace, "namespace", "n", "default", "Namespace")
+	injectDeploymentCmd.Flags().StringVarP(&ServerImage, "server-image", "i", k8s.Image, "Ktunnel server image to use")
 	injectCmd.AddCommand(injectDeploymentCmd)
 	rootCmd.AddCommand(injectCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	version = "1.2.8b"
+	version = "1.3.0"
 )
 
 var Port int
@@ -38,6 +38,10 @@ func Execute() {
 		TimestampFormat: "2006-01-02 15:04:05",
 	})
 
+	if Verbose {
+		log.SetLevel(log.DebugLevel)
+	}
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -47,6 +51,6 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().IntVarP(&Port, "port", "p", 28688, "The port to use to establish the tunnel")
 	rootCmd.PersistentFlags().BoolVarP(&Tls, "tls", "t", false, "Connection uses TLS if true, else plain TCP")
-	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "Emit debug logs")
+	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "Verbose mode")
 	_ = rootCmd.MarkFlagRequired("port")
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -1,6 +1,12 @@
 package cmd
 
 import (
+	"context"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
 	"github.com/omrikiei/ktunnel/pkg/server"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -18,10 +24,23 @@ var serverCmd = &cobra.Command{
 ktunnel server -p 8181
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithCancel(context.Background())
 		if Verbose {
 			log.SetLevel(log.DebugLevel)
 		}
-		err := server.RunServer(&Port, &Tls, &KeyFile, &CertFile)
+		o := sync.Once{}
+		// Run tunnel client and establish connection
+
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGKILL, syscall.SIGQUIT)
+		go func() {
+			o.Do(func() {
+				_ = <-sigs
+				log.Info("Got exit signal, closing client tunnels")
+				cancel()
+			})
+		}()
+		err := server.RunServer(ctx, &Port, &Tls, &KeyFile, &CertFile)
 		if err != nil {
 			log.Fatalf("Error running server: %v", err)
 		}

--- a/examples/pycharm-remote-debugging-on-k8s/deployment.yaml
+++ b/examples/pycharm-remote-debugging-on-k8s/deployment.yaml
@@ -1,5 +1,5 @@
 # deployment.yaml
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -22,44 +21,47 @@ type Message struct {
 	d *[]byte
 }
 
-func ReceiveData(st *pb.Tunnel_InitTunnelClient, closeStream <-chan struct{}, sessionsOut chan<- *common.Session, port int32, scheme string) {
-	stream := *st
+func ReceiveData(ctx context.Context, st pb.Tunnel_InitTunnelClient, sessionsOut chan<- *common.Session, port int32, scheme string) {
 loop:
 	for {
 		select {
-		case <-closeStream:
-			log.Infof("stopping to receive data on port %d", port)
-			_ = stream.CloseSend()
+		case <-ctx.Done():
+			log.WithError(ctx.Err()).Infof("stopping to receive data on port %d", port)
+			_ = st.CloseSend()
 			break loop
 		default:
 			log.Debugf("attempting to receive from stream")
-			m, err := stream.Recv()
+			m, err := st.Recv()
 			if err != nil {
-				log.Warnf("error reading from stream; %v", err)
+				log.WithError(err).Warnf("error reading from stream")
 				break loop
 			}
-			log.Debugf("%s; got session from server: %s", m.RequestId, m.GetData())
+
 			requestId, err := uuid.Parse(m.RequestId)
 			if err != nil {
-				log.Errorf("%s; failed parsing session uuid from stream, skipping", m.RequestId)
+				log.WithError(err).WithField("session", m.RequestId).Errorf("failed parsing session uuid from stream, skipping")
 			}
+
 			session, exists := common.GetSession(requestId)
 			if exists == false {
-				if m.ShouldClose != true {
-					log.Infof("%s; new session; connecting to port %d", m.RequestId, port)
-					// new session
-					conn, err := net.DialTimeout(strings.ToLower(scheme), fmt.Sprintf("localhost:%d", port), time.Millisecond*500)
-					if err != nil {
-						log.Errorf("failed connecting to localhost on port %d scheme %s: %v", port, scheme, err)
-						break loop
-					}
-					session = common.NewSessionFromStream(requestId, conn)
-					go ReadFromSession(session, sessionsOut)
-				} else {
-					session = common.NewSessionFromStream(requestId, nil)
-					session.Open = false
+				log.WithFields(log.Fields{
+					"session": m.RequestId,
+					"port":    port,
+				}).Infof("new connection")
+
+				// new session
+				conn, err := net.DialTimeout(strings.ToLower(scheme), fmt.Sprintf("localhost:%d", port), time.Millisecond*500)
+				if err != nil {
+					log.WithError(err).Errorf("failed connecting to localhost on port %d scheme %s", port, scheme)
+					break loop
 				}
+				session = common.NewSessionFromStream(requestId, conn)
+				go ReadFromSession(session, sessionsOut)
+			} else if m.ShouldClose {
+				session.Open = false
 			}
+
+			// process the data from the server
 			handleStreamData(m, session)
 		}
 	}
@@ -67,53 +69,54 @@ loop:
 
 func handleStreamData(m *pb.SocketDataResponse, session *common.Session) {
 	if session.Open == false {
+		log.WithField("session", session.Id).Infof("closed session")
 		session.Close()
-	} else {
-		c := session.Conn
-		data := m.GetData()
-		log.Debugf("%s got %d bytes", session.Id, len(data))
-		if len(data) > 0 {
-			session.Lock.Lock()
-			_, err := c.Write(data)
-			session.Lock.Unlock()
-			if err != nil {
-				log.Printf("%s; failed writing to socket, closing session: %v", session.Id.String(), err)
-				session.Close()
-			}
+		return
+	}
+
+	data := m.GetData()
+	log.WithField("session", session.Id).Infof("received %d bytes from server", len(data))
+	if len(data) > 0 {
+		session.Lock.Lock()
+		log.WithField("session", session.Id).Infof("wrote %d bytes to conn", len(data))
+		_, err := session.Conn.Write(data)
+		session.Lock.Unlock()
+		if err != nil {
+			log.WithError(err).WithField("session", session.Id).Errorf("failed writing to socket, closing session")
+			session.Close()
+			return
 		}
 	}
 }
 
 func ReadFromSession(session *common.Session, sessionsOut chan<- *common.Session) {
 	conn := session.Conn
-	log.Debugf("started reading from session %s", session.Id)
-	buff := make([]byte, common.BufferSize)
+	log.WithField("session", session.Id).Debugf("started reading conn")
+
 	for {
-		//_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+		buff := make([]byte, common.BufferSize)
 		br, err := conn.Read(buff)
+
 		if err != nil {
 			if err != io.EOF {
-				log.Errorf("%s; failed reading from socket, exiting: %v", session.Id.String(), err)
+				log.WithError(err).WithField("session", session.Id).Errorf("failed reading from socket")
 			}
 			session.Open = false
 			sessionsOut <- session
 			break
 		}
-		log.Debugf("read %d bytes from conn on session %s; err: %v", br, session.Id, err)
-		log.Debugf("locking: %s", session.Id)
+
+		log.WithField("session", session.Id).WithError(err).Infof("read %d bytes from conn", br)
+
+		session.Lock.Lock()
 		if br > 0 {
-			session.Lock.Lock()
-			_, err = session.Buf.Write(buff[:br])
-			session.Lock.Unlock()
-			if br == len(buff) && len(buff) < common.MaxBufferSize {
-				newSize := len(buff) * 2
-				log.Infof("increasing buffer size to %d", newSize)
-				buff = make([]byte, newSize)
-			}
+			log.WithField("session", session.Id).WithError(err).Infof("wrote %d bytes to session buf", br)
+			_, err = session.Buf.Write(buff[0:br])
 		}
-		log.Debugf("unlocked: %s", session.Id)
+		session.Lock.Unlock()
+
 		if err != nil {
-			log.Errorf("%s; failed writing to session buffer: %v", session.Id, err)
+			log.WithField("session", session.Id).WithError(err).Errorf("failed writing to session buffer")
 			break
 		}
 		sessionsOut <- session
@@ -121,43 +124,47 @@ func ReadFromSession(session *common.Session, sessionsOut chan<- *common.Session
 	log.Debugf("finished reading from session %s", session.Id)
 }
 
-func SendData(stream *pb.Tunnel_InitTunnelClient, sessions <-chan *common.Session, closeChan <-chan struct{}) {
+func SendData(ctx context.Context, stream pb.Tunnel_InitTunnelClient, sessions <-chan *common.Session) {
 	for {
 		select {
-		case <-closeChan:
+		case <-ctx.Done():
 			return
 		case session := <-sessions:
+
+			// read the bytes from the buffer
+			// but allow it to keep growing while we send the response
 			session.Lock.Lock()
-			st := *stream
+			bys := session.Buf.Len()
+			bytes := make([]byte, bys)
+			session.Buf.Read(bytes)
+
+			log.WithField("session", session.Id).Infof("read %d from buffer out of %d available", len(bytes), bys)
+
 			resp := &pb.SocketDataRequest{
 				RequestId:   session.Id.String(),
-				Data:        session.Buf.Bytes(),
-				ShouldClose: false,
+				Data:        bytes,
+				ShouldClose: !session.Open,
 			}
-			if session.Open == false {
-				resp.ShouldClose = true
-			}
-			session.Buf.Reset()
 			session.Lock.Unlock()
-			go func() {
-				err := st.Send(resp)
-				if err != nil {
-					log.Errorf("failed sending message to tunnel stream, exiting; %v", err)
-				}
-			}()
+
+			log.WithFields(log.Fields{
+				"session": session.Id,
+				"close":   resp.ShouldClose,
+			}).Infof("sending %d bytes to server", len(bytes))
+			err := stream.Send(resp)
+			if err != nil {
+				log.WithError(err).Errorf("failed sending message to tunnel stream, exiting")
+				return
+			}
+			log.WithFields(log.Fields{
+				"session": session.Id,
+				"close":   resp.ShouldClose,
+			}).Infof("sent %d bytes to server", len(bytes))
 		}
 	}
 }
 
 func RunClient(ctx context.Context, host *string, port *int, scheme string, tls *bool, caFile, serverHostOverride *string, tunnels []string) error {
-	wg := sync.WaitGroup{}
-	closeStreams := make([]chan struct{}, len(tunnels))
-	go func() {
-		<-ctx.Done()
-		for _, c := range closeStreams {
-			close(c)
-		}
-	}()
 	var opts []grpc.DialOption
 	if *tls {
 		creds, err := credentials.NewClientTLSFromFile(*caFile, *serverHostOverride)
@@ -168,51 +175,50 @@ func RunClient(ctx context.Context, host *string, port *int, scheme string, tls 
 	} else {
 		opts = append(opts, grpc.WithInsecure())
 	}
+
 	conn, err := grpc.Dial(fmt.Sprintf("%s:%d", *host, *port), opts...)
 	if err != nil {
 		log.Fatalf("fail to dial: %v", err)
 	}
-	defer func() {
-		_ = conn.Close()
-	}()
+	defer conn.Close()
+
 	client := pb.NewTunnelClient(conn)
-	for i, rawTunnelData := range tunnels {
+	for _, rawTunnelData := range tunnels {
 		tunnelData, err := common.ParsePorts(rawTunnelData)
 		if err != nil {
 			log.Error(err)
 		}
-		wg.Add(1)
-		c := make(chan struct{}, 1)
-		go func(closeStream chan struct{}) {
+		go func() {
 			log.Println(fmt.Sprintf("starting %s tunnel from source %d to target %d", scheme, tunnelData.Source, tunnelData.Target))
-			ctx := context.Background()
 			tunnelScheme, ok := pb.TunnelScheme_value[scheme]
 			if ok != false {
 				log.Fatalf("unsupported connection scheme %s", scheme)
 			}
+
 			req := &pb.SocketDataRequest{
 				Port:     tunnelData.Source,
 				LogLevel: 0,
 				Scheme:   pb.TunnelScheme(tunnelScheme),
 			}
+
 			stream, err := client.InitTunnel(ctx)
 			if err != nil {
 				log.Errorf("Error sending init tunnel request: %v", err)
 			} else {
 				err := stream.Send(req)
 				if err != nil {
-					log.Errorf("Failed to send initial tunnel request to server")
+					log.WithError(err).Errorf("Failed to send initial tunnel request to server")
 				} else {
 					sessions := make(chan *common.Session)
-					go ReceiveData(&stream, closeStream, sessions, tunnelData.Target, scheme)
-					go SendData(&stream, sessions, closeStream)
-					<-closeStream
+					go ReceiveData(ctx, stream, sessions, tunnelData.Target, scheme)
+					go SendData(ctx, stream, sessions)
+					<-ctx.Done()
 				}
 			}
-			wg.Done()
-		}(c)
-		closeStreams[i] = c
+
+		}()
 	}
-	wg.Wait()
+
+	<-ctx.Done()
 	return nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -111,7 +111,7 @@ func ReadFromSession(conf *ClientConfig, session *common.Session, sessionsOut ch
 		br, err := conn.Read(buff)
 
 		if err != nil {
-			if err != io.EOF {
+			if err == io.EOF {
 				break
 			}
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -88,10 +88,10 @@ func handleStreamData(conf *ClientConfig, m *pb.SocketDataResponse, session *com
 	}
 
 	data := m.GetData()
-	conf.log.WithField("session", session.Id).Infof("received %d bytes from server", len(data))
+	conf.log.WithField("session", session.Id).Debugf("received %d bytes from server", len(data))
 	if len(data) > 0 {
 		session.Lock.Lock()
-		conf.log.WithField("session", session.Id).Infof("wrote %d bytes to conn", len(data))
+		conf.log.WithField("session", session.Id).Debugf("wrote %d bytes to conn", len(data))
 		_, err := session.Conn.Write(data)
 		session.Lock.Unlock()
 		if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -17,10 +17,6 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-const (
-	bufferSize = 1024 * 32
-)
-
 type Message struct {
 	c *net.Conn
 	d *[]byte
@@ -55,7 +51,7 @@ loop:
 					conn, err := net.DialTimeout(strings.ToLower(scheme), fmt.Sprintf("localhost:%d", port), time.Millisecond*500)
 					if err != nil {
 						log.Errorf("failed connecting to localhost on port %d scheme %s: %v", port, scheme, err)
-						return
+						break loop
 					}
 					session = common.NewSessionFromStream(requestId, conn)
 					go ReadFromSession(session, sessionsOut)
@@ -71,12 +67,7 @@ loop:
 
 func handleStreamData(m *pb.SocketDataResponse, session *common.Session) {
 	if session.Open == false {
-		if session.Conn != nil {
-			ok, err := common.CloseSession(session.Id)
-			if ok != true {
-				log.Printf("%s; failed closing session: %v", session.Id.String(), err)
-			}
-		}
+		session.Close()
 	} else {
 		c := session.Conn
 		data := m.GetData()
@@ -87,10 +78,7 @@ func handleStreamData(m *pb.SocketDataResponse, session *common.Session) {
 			session.Lock.Unlock()
 			if err != nil {
 				log.Printf("%s; failed writing to socket, closing session: %v", session.Id.String(), err)
-				ok, err := common.CloseSession(session.Id)
-				if ok != true {
-					log.Printf("%s; failed closing session: %v", session.Id.String(), err)
-				}
+				session.Close()
 			}
 		}
 	}
@@ -99,7 +87,7 @@ func handleStreamData(m *pb.SocketDataResponse, session *common.Session) {
 func ReadFromSession(session *common.Session, sessionsOut chan<- *common.Session) {
 	conn := session.Conn
 	log.Debugf("started reading from session %s", session.Id)
-	buff := make([]byte, bufferSize)
+	buff := make([]byte, common.BufferSize)
 	for {
 		//_ = conn.SetReadDeadline(time.Now().Add(time.Second))
 		br, err := conn.Read(buff)
@@ -117,7 +105,7 @@ func ReadFromSession(session *common.Session, sessionsOut chan<- *common.Session
 			session.Lock.Lock()
 			_, err = session.Buf.Write(buff[:br])
 			session.Lock.Unlock()
-			if br == len(buff) {
+			if br == len(buff) && len(buff) < common.MaxBufferSize {
 				newSize := len(buff) * 2
 				log.Infof("increasing buffer size to %d", newSize)
 				buff = make([]byte, newSize)

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	"github.com/google/uuid"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -47,10 +46,7 @@ func NewSession(conn net.Conn) *Session {
 		Buf:  bytes.Buffer{},
 		Open: true,
 	}
-	ok, err := addSession(r)
-	if ok != true {
-		log.Printf("%s; failed registering request: %v", r.Id.String(), err)
-	}
+	addSession(r)
 	return r
 }
 
@@ -61,10 +57,7 @@ func NewSessionFromStream(id uuid.UUID, conn net.Conn) *Session {
 		Buf:  bytes.Buffer{},
 		Open: true,
 	}
-	ok, err := addSession(r)
-	if ok != true {
-		log.Errorf("%s; failed registering request: %v", r.Id.String(), err)
-	}
+	addSession(r)
 	return r
 }
 

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -12,12 +12,28 @@ import (
 	"sync"
 )
 
+const (
+	BufferSize    = 1024 * 4
+	MaxBufferSize = 1024 * 64
+)
+
+var openSessions = sync.Map{}
+
 type Session struct {
 	Id   uuid.UUID
 	Conn net.Conn
 	Buf  bytes.Buffer
 	Open bool
 	Lock sync.RWMutex
+}
+
+func (s *Session) Close() {
+	if s.Conn != nil {
+		s.Lock.Lock()
+		_ = s.Conn.Close()
+		s.Lock.Unlock()
+	}
+	openSessions.Delete(s.Id)
 }
 
 type RedirectRequest struct {
@@ -32,7 +48,7 @@ func NewSession(conn net.Conn) *Session {
 		Buf:  bytes.Buffer{},
 		Open: true,
 	}
-	ok, err := AddSession(r)
+	ok, err := addSession(r)
 	if ok != true {
 		log.Printf("%s; failed registering request: %v", r.Id.String(), err)
 	}
@@ -46,14 +62,14 @@ func NewSessionFromStream(id uuid.UUID, conn net.Conn) *Session {
 		Buf:  bytes.Buffer{},
 		Open: true,
 	}
-	ok, err := AddSession(r)
+	ok, err := addSession(r)
 	if ok != true {
 		log.Errorf("%s; failed registering request: %v", r.Id.String(), err)
 	}
 	return r
 }
 
-func AddSession(r *Session) (bool, error) {
+func addSession(r *Session) (bool, error) {
 	if _, ok := GetSession(r.Id); ok != false {
 		return false, errors.New(fmt.Sprintf("Session %s already exists", r.Id.String()))
 	}
@@ -67,21 +83,6 @@ func GetSession(id uuid.UUID) (*Session, bool) {
 		return request.(*Session), ok
 	}
 	return nil, ok
-}
-
-var openSessions = sync.Map{}
-
-func CloseSession(id uuid.UUID) (bool, error) {
-	session, ok := GetSession(id)
-	if ok == false {
-		return true, nil
-	}
-	session.Lock.Lock()
-	conn := session.Conn
-	err := conn.Close()
-	session.Lock.Unlock()
-	openSessions.Delete(id)
-	return true, err
 }
 
 func ParsePorts(s string) (*RedirectRequest, error) {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -24,15 +24,13 @@ type Session struct {
 	Conn net.Conn
 	Buf  bytes.Buffer
 	Open bool
-	Lock sync.RWMutex
+	Lock sync.Mutex
 }
 
 func (s *Session) Close() {
 	if s.Conn != nil {
-		s.Lock.Lock()
 		_ = s.Conn.Close()
 		s.Open = false
-		s.Lock.Unlock()
 	}
 	openSessions.Delete(s.Id)
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -4,17 +4,18 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/google/uuid"
-	log "github.com/sirupsen/logrus"
 	"net"
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
-	BufferSize    = 1024 * 4
-	MaxBufferSize = 1024 * 64
+	BufferSize    = 1024 * 1
+	MaxBufferSize = 1024 * 3
 )
 
 var openSessions = sync.Map{}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -14,8 +14,7 @@ import (
 )
 
 const (
-	BufferSize    = 1024 * 1
-	MaxBufferSize = 1024 * 3
+	BufferSize = 1024 * 3
 )
 
 var openSessions = sync.Map{}
@@ -32,6 +31,7 @@ func (s *Session) Close() {
 	if s.Conn != nil {
 		s.Lock.Lock()
 		_ = s.Conn.Close()
+		s.Open = false
 		s.Lock.Unlock()
 	}
 	openSessions.Delete(s.Id)

--- a/pkg/k8s/common.go
+++ b/pkg/k8s/common.go
@@ -1,6 +1,8 @@
 package k8s
 
 import (
+	"bytes"
+	"fmt"
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
@@ -15,9 +17,13 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/openstack"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
 	"k8s.io/client-go/util/homedir"
+	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -25,8 +31,16 @@ import (
 )
 
 const (
-	image = "quay.io/omrikiei/ktunnel:latest"
+	Image = "quay.io/omrikiei/ktunnel:latest"
 )
+
+type ByCreationTime []apiv1.Pod
+
+func (a ByCreationTime) Len() int { return len(a) }
+func (a ByCreationTime) Less(i, j int) bool {
+	return a[i].CreationTimestamp.After(a[j].CreationTimestamp.Time)
+}
+func (a ByCreationTime) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 
 var deploymentOnce = sync.Once{}
 var deploymentsClient v1.DeploymentInterface
@@ -63,7 +77,7 @@ func getClients(namespace *string) {
 	})
 }
 
-func getAllPods(namespace, deployment *string) (*apiv1.PodList, error) {
+func getAllPods(namespace *string) (*apiv1.PodList, error) {
 	getClients(namespace)
 	// TODO: filter pod list
 	pods, err := podsClient.List(metav1.ListOptions{})
@@ -73,24 +87,8 @@ func getAllPods(namespace, deployment *string) (*apiv1.PodList, error) {
 	return pods, nil
 }
 
-func waitForReady(name *string, ti *time.Time, numPods int32, readyChan chan<- bool) {
+func waitForReady(name *string, ti time.Time, numPods int32, readyChan chan<- bool) {
 	go func() {
-		/*
-			watcher, err := podsClient.Watch(metav1.ListOptions{
-				TypeMeta:            metav1.TypeMeta{
-					Kind: "pod",
-				},
-				Watch:               true,
-			})
-			if err != nil {
-				return
-			}
-
-			for e := range watcher.ResultChan(){
-				if e.Type == watch.Deleted {
-					break
-				}
-			}*/
 		for {
 			count := int32(0)
 			pods, err := podsClient.List(metav1.ListOptions{})
@@ -99,10 +97,10 @@ func waitForReady(name *string, ti *time.Time, numPods int32, readyChan chan<- b
 				os.Exit(1)
 			}
 			for _, p := range pods.Items {
-				if strings.HasPrefix(p.Name, *name) && p.CreationTimestamp.After(*ti) && p.Status.Phase == apiv1.PodRunning {
+				if strings.HasPrefix(p.Name, *name) && p.CreationTimestamp.After(ti) && p.Status.Phase == apiv1.PodRunning {
 					count += 1
 				}
-				if count >= numPods {
+				if count == numPods {
 					readyChan <- true
 					break
 				}
@@ -112,7 +110,7 @@ func waitForReady(name *string, ti *time.Time, numPods int32, readyChan chan<- b
 	}()
 }
 
-func hasSidecar(podSpec apiv1.PodSpec) bool {
+func hasSidecar(podSpec apiv1.PodSpec, image string) bool {
 	for _, c := range podSpec.Containers {
 		if c.Image == image {
 			return true
@@ -121,7 +119,7 @@ func hasSidecar(podSpec apiv1.PodSpec) bool {
 	return false
 }
 
-func newContainer(port int) *apiv1.Container {
+func newContainer(port int, image string) *apiv1.Container {
 	args := []string{"server", "-p", strconv.FormatInt(int64(port), 10)}
 	if Verbose == true {
 		args = append(args, "-v")
@@ -139,20 +137,20 @@ func newContainer(port int) *apiv1.Container {
 		Args:    args,
 		Resources: apiv1.ResourceRequirements{
 			Requests: apiv1.ResourceList{
-				"cpu": cpuRequest,
+				"cpu":    cpuRequest,
 				"memory": memRequest,
 			},
 			Limits: apiv1.ResourceList{
-				"cpu": cpuLimit,
+				"cpu":    cpuLimit,
 				"memory": memLimit,
 			},
 		},
 	}
 }
 
-func newDeployment(namespace, name string, port int) *appsv1.Deployment {
+func newDeployment(namespace, name string, port int, image string) *appsv1.Deployment {
 	replicas := int32(1)
-	co := newContainer(port)
+	co := newContainer(port, image)
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
@@ -205,4 +203,91 @@ func newService(namespace, name string, ports []apiv1.ServicePort) *apiv1.Servic
 			},
 		},
 	}
+}
+
+func getPodNames(namespace, deploymentName *string, podsPtr *[]string) error {
+	allPods, err := getAllPods(namespace)
+	if err != nil {
+		return err
+	}
+	pods := *podsPtr
+	matchinePods := ByCreationTime{}
+	pIndex := 0
+	for _, p := range allPods.Items {
+		if pIndex >= len(pods) {
+			log.Info("All pods located for port-forwarding")
+			break
+		}
+		if strings.HasPrefix(p.Name, *deploymentName) && p.Status.Phase == apiv1.PodRunning {
+			matchinePods = append(matchinePods, p)
+		}
+	}
+	sort.Sort(matchinePods)
+	for i := 0; i < len(pods); i++ {
+		pods[i] = matchinePods[i].Name
+	}
+
+	return nil
+
+}
+
+func PortForward(namespace, deploymentName *string, targetPort string, fwdWaitGroup *sync.WaitGroup, stopChan <-chan struct{}) (*[]string, error) {
+	getClients(namespace)
+
+	out, errOut := new(bytes.Buffer), new(bytes.Buffer)
+	deployment, err := deploymentsClient.Get(*deploymentName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	podNames := make([]string, *deployment.Spec.Replicas)
+	err = getPodNames(namespace, deploymentName, &podNames)
+	fwdWaitGroup.Add(int(*deployment.Spec.Replicas))
+
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("Injecting to this pods: %v", podNames)
+	sourcePorts := make([]string, *deployment.Spec.Replicas)
+	numPort, err := strconv.ParseInt(targetPort, 10, 32)
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < len(sourcePorts); i++ {
+		sourcePorts[i] = strconv.FormatInt(numPort+int64(i), 10)
+	}
+	for i, podName := range podNames {
+		readyChan := make(chan struct{}, 1)
+		ports := []string{fmt.Sprintf("%s:%s", sourcePorts[i], targetPort)}
+		serverURL := getPortForwardUrl(kubeconfig, *namespace, podName)
+
+		transport, upgrader, err := spdy.RoundTripperFor(kubeconfig)
+		if err != nil {
+			return nil, err
+		}
+		dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, serverURL)
+
+		forwarder, err := portforward.New(dialer, ports, stopChan, readyChan, out, errOut)
+		if err != nil {
+			log.Error(err)
+		}
+
+		go func() {
+			for range readyChan { // Kubernetes will close this channel when it has something to tell us.
+			}
+			if len(errOut.String()) != 0 {
+				log.Error(errOut.String())
+			} else if len(out.String()) != 0 {
+				log.Info(out.String())
+				if strings.HasPrefix(out.String(), "Forwarding") {
+					fwdWaitGroup.Done()
+				}
+			}
+		}()
+		go func() {
+			if err = forwarder.ForwardPorts(); err != nil { // Locks until stopChan is closed.
+				log.Error(err)
+			}
+		}()
+	}
+	return &sourcePorts, nil
 }

--- a/pkg/k8s/exposer.go
+++ b/pkg/k8s/exposer.go
@@ -15,9 +15,9 @@ var supportedSchemes = map[string]v12.Protocol{
 	"ufp": v12.ProtocolUDP,
 }
 
-func ExposeAsService(namespace, name *string, tunnelPort int, scheme string, rawPorts []string, readyChan chan<- bool) error {
+func ExposeAsService(namespace, name *string, tunnelPort int, scheme string, rawPorts []string, image string, readyChan chan<- bool) error {
 	getClients(namespace)
-	deployment := newDeployment(*namespace, *name, tunnelPort)
+	deployment := newDeployment(*namespace, *name, tunnelPort, image)
 
 	ports := make([]v12.ServicePort, len(rawPorts))
 	protocol, ok := supportedSchemes[scheme]
@@ -52,7 +52,7 @@ func ExposeAsService(namespace, name *string, tunnelPort int, scheme string, raw
 		return err
 	}
 	log.Infof("Exposed service's cluster ip is: %s", newSvc.Spec.ClusterIP)
-	waitForReady(name, &creationTime, *deployment.Spec.Replicas, readyChan)
+	waitForReady(name, creationTime, *deployment.Spec.Replicas, readyChan)
 	return nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -92,7 +92,7 @@ func ReceiveData(conf *ServerConfig, stream pb.Tunnel_InitTunnelServer, closeCha
 		conf.log.WithFields(log.Fields{
 			"session": session.Id,
 			"close":   message.ShouldClose,
-		}).Infof("received %d bytes from client", len(data))
+		}).Debugf("received %d bytes from client", len(data))
 
 		// send data if we received any
 		if br > 0 {
@@ -102,7 +102,7 @@ func ReceiveData(conf *ServerConfig, stream pb.Tunnel_InitTunnelServer, closeCha
 				conf.log.WithError(err).WithField("session", reqId).Errorf("failed writing data to socket")
 				message.ShouldClose = true
 			} else {
-				conf.log.WithField("session", reqId).Infof("wrote %d bytes to conn", br)
+				conf.log.WithField("session", reqId).Debugf("wrote %d bytes to conn", br)
 			}
 		}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2,11 +2,13 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/google/uuid"
 	"github.com/omrikiei/ktunnel/pkg/common"
@@ -16,13 +18,19 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-type tunnelServer struct{}
-
-func NewServer() *tunnelServer {
-	return &tunnelServer{}
+type tunnelServer struct {
+	conf *ServerConfig
 }
 
-func SendData(stream pb.Tunnel_InitTunnelServer, sessions <-chan *common.Session, closeChan chan<- bool) {
+// NewServer creates a new GRPC handler instance that
+// can be attached to a GRPC server
+func NewServer(conf *ServerConfig) *tunnelServer {
+	return &tunnelServer{conf}
+}
+
+// SendData handles data coming from our TCP listener, via the sessions channel, and
+// republishes it over GRPC
+func SendData(conf *ServerConfig, stream pb.Tunnel_InitTunnelServer, sessions <-chan *common.Session, closeChan chan<- bool) {
 	for {
 		session := <-sessions
 
@@ -42,84 +50,84 @@ func SendData(stream pb.Tunnel_InitTunnelServer, sessions <-chan *common.Session
 		}
 		session.Lock.Unlock()
 
-		log.WithFields(log.Fields{
+		conf.log.WithFields(log.Fields{
 			"session": session.Id,
 			"close":   resp.ShouldClose,
-		}).Infof("sending %d bytes to client", len(bytes))
+		}).Debugf("sending %d bytes to client", len(bytes))
 		err := stream.Send(resp)
 		if err != nil {
-			log.WithError(err).Errorf("failed sending message to tunnel stream, exiting")
-			return
+			conf.log.WithError(err).Errorf("failed sending message to tunnel stream")
+			continue
 		}
-		log.WithFields(log.Fields{
+		conf.log.WithFields(log.Fields{
 			"session": session.Id,
 			"close":   resp.ShouldClose,
-		}).Infof("sent %d bytes to client", len(bytes))
+		}).Debugf("sent %d bytes to client", len(bytes))
 	}
 }
 
-func ReceiveData(stream pb.Tunnel_InitTunnelServer, closeChan chan<- bool) {
+func ReceiveData(conf *ServerConfig, stream pb.Tunnel_InitTunnelServer, closeChan chan<- bool) {
 	for {
 		message, err := stream.Recv()
 		if err != nil {
-			log.WithError(err).Warnf("failed receiving message from stream")
+			conf.log.WithError(err).Warnf("failed receiving message from stream")
 			continue
 		}
 
 		reqId, err := uuid.Parse(message.GetRequestId())
 		if err != nil {
-			log.WithError(err).WithField("session", message.GetRequestId()).Errorf("failed to parse requestId")
+			conf.log.WithError(err).WithField("session", message.GetRequestId()).Errorf("failed to parse requestId")
 			continue
 		}
 
 		session, ok := common.GetSession(reqId)
 		if ok != true {
-			log.WithField("session", reqId).Errorf("session not found in openRequests")
+			conf.log.WithField("session", reqId).Errorf("session not found in openRequests")
 			continue
 		}
 
 		data := message.GetData()
 		br := len(data)
 
-		log.WithFields(log.Fields{
+		conf.log.WithFields(log.Fields{
 			"session": session.Id,
 			"close":   message.ShouldClose,
 		}).Infof("received %d bytes from client", len(data))
 
 		// send data if we received any
 		if br > 0 {
-			log.WithField("session", reqId).Infof("writing %d bytes to conn", br)
+			conf.log.WithField("session", reqId).Debugf("writing %d bytes to conn", br)
 			_, err := session.Conn.Write(data)
 			if err != nil {
-				log.WithError(err).WithField("session", reqId).Errorf("failed writing data to socket")
+				conf.log.WithError(err).WithField("session", reqId).Errorf("failed writing data to socket")
 				message.ShouldClose = true
 			} else {
-				log.WithField("session", reqId).Infof("wrote %d bytes to conn", br)
+				conf.log.WithField("session", reqId).Infof("wrote %d bytes to conn", br)
 			}
 		}
 
 		if message.ShouldClose == true {
-			log.WithField("session", reqId).Infof("closing session")
+			conf.log.WithField("session", reqId).Debug("closing session")
 			session.Close()
-			log.WithField("session", reqId).Infof("closed session")
+			conf.log.WithField("session", reqId).Debug("closed session")
 		}
 	}
 }
 
-func readConn(session *common.Session, sessions chan<- *common.Session) {
-	log.WithField("session", session.Id.String()).Info("new conn connection")
+func readConn(conf *ServerConfig, session *common.Session, sessions chan<- *common.Session) {
+	conf.log.WithField("session", session.Id.String()).Info("new conn connection")
 
 	for {
 		buff := make([]byte, common.BufferSize)
 		br, err := session.Conn.Read(buff)
-		log.WithError(err).Infof("read %d bytes from conn", br)
+		conf.log.WithError(err).Infof("read %d bytes from conn", br)
 
 		session.Lock.Lock()
 		if err != nil {
 			if err == io.EOF {
 				return
 			}
-			log.WithError(err).WithField("session", session.Id).Infof("failed to read from conn")
+			conf.log.WithError(err).WithField("session", session.Id).Infof("failed to read from conn")
 
 			// setting Open to false triggers SendData() to
 			// send ShouldClose
@@ -142,7 +150,7 @@ func readConn(session *common.Session, sessions chan<- *common.Session) {
 func (t *tunnelServer) InitTunnel(stream pb.Tunnel_InitTunnelServer) error {
 	request, err := stream.Recv()
 	if err != nil {
-		log.Fatalf("Failed receiving initial connection from tunnel")
+		return errors.Wrap(err, "failed to read handshake")
 	}
 
 	port := request.GetPort()
@@ -157,17 +165,18 @@ func (t *tunnelServer) InitTunnel(stream pb.Tunnel_InitTunnelServer) error {
 		if err != nil {
 			return err
 		}
-		return errors.New("missing port")
+
+		return fmt.Errorf("missing port")
 	}
 
-	log.WithFields(log.Fields{
+	t.conf.log.WithFields(log.Fields{
 		"port":   port,
 		"schema": request.GetScheme(),
 	}).Infof("opening connection")
 	ln, err := net.Listen(strings.ToLower(request.GetScheme().String()), fmt.Sprintf(":%d", port))
 	if err != nil {
 		defer func() {
-			log.WithError(err).Errorf("Failed listening on port %d", port)
+			t.conf.log.WithError(err).Errorf("Failed listening on port %d", port)
 		}()
 		_ = stream.Send(&pb.SocketDataResponse{
 			HasErr: true,
@@ -183,36 +192,52 @@ func (t *tunnelServer) InitTunnel(stream pb.Tunnel_InitTunnelServer) error {
 	closeChan := make(chan bool, 1)
 	go func(close <-chan bool) {
 		<-close
-		log.WithField("port", port).Infof("closing connection")
+		t.conf.log.WithField("port", port).Infof("closing connection")
 		_ = ln.Close()
 	}(closeChan)
 
 	go func() {
-		ReceiveData(stream, closeChan)
-		log.WithField("port", port).Warnf("client receiver died (client -> conn)")
+		ReceiveData(t.conf, stream, closeChan)
+		t.conf.log.WithField("port", port).Debug("client receiver died (client -> conn)")
 	}()
 	go func() {
-		SendData(stream, sessions, closeChan)
-		log.WithField("port", port).Warnf("conn receiver died (conn -> client)")
+		SendData(t.conf, stream, sessions, closeChan)
+		t.conf.log.WithField("port", port).Debug("conn receiver died (conn -> client)")
 	}()
 
 	for {
 		connection, err := ln.Accept()
-		log.Debugf("Accepted new connection %v; %v", connection, err)
+		t.conf.log.WithError(err).Debugf("Accepted new connection %v", connection)
 		if err != nil {
 			return err
 		}
+
 		// socket -> stream
 		session := common.NewSession(connection)
-		go readConn(session, sessions)
+		go readConn(t.conf, session, sessions)
 	}
 }
 
-func RunServer(ctx context.Context, port *int, tls *bool, keyFile, certFile *string) error {
-	log.Infof("Starting to listen on port %d", *port)
-	lis, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", *port))
+// RunServer creates a GRPC tunnel
+func RunServer(ctx context.Context, opts ...ServerOption) error {
+	conf, err := processArgs(opts)
 	if err != nil {
-		log.Fatalf("failed to listen: %v", err)
+		return errors.Wrap(err, "failed to parse arguments")
+	}
+
+	var grpcOpts []grpc.ServerOption
+	if conf.TLS {
+		creds, err := credentials.NewServerTLSFromFile(conf.certFile, conf.keyFile)
+		if err != nil {
+			conf.log.Fatalf("Failed to generate credentials %v", err)
+		}
+		grpcOpts = []grpc.ServerOption{grpc.Creds(creds)}
+	}
+
+	conf.log.Infof("Starting to listen on port %d", conf.port)
+	lis, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", conf.port))
+	if err != nil {
+		return errors.Wrap(err, "failed to start GRPC listener")
 	}
 
 	// handle context cancellation, shut down the server
@@ -221,16 +246,70 @@ func RunServer(ctx context.Context, port *int, tls *bool, keyFile, certFile *str
 		lis.Close()
 	}()
 
-	var opts []grpc.ServerOption
-	if *tls {
-		creds, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)
-		if err != nil {
-			log.Fatalf("Failed to generate credentials %v", err)
-		}
-		opts = []grpc.ServerOption{grpc.Creds(creds)}
+	grpcServer := grpc.NewServer(grpcOpts...)
+	pb.RegisterTunnelServer(grpcServer, NewServer(conf))
+	return grpcServer.Serve(lis)
+}
+
+// processArgs processes functional args
+func processArgs(opts []ServerOption) (*ServerConfig, error) {
+	// default arguments
+	opt := &ServerConfig{
+		port: 5000,
+		log: &log.Logger{
+			Out: ioutil.Discard,
+		},
+		TLS: false,
 	}
 
-	grpcServer := grpc.NewServer(opts...)
-	pb.RegisterTunnelServer(grpcServer, NewServer())
-	return grpcServer.Serve(lis)
+	for _, f := range opts {
+		if err := f(opt); err != nil {
+			return nil, err
+		}
+	}
+
+	return opt, nil
+}
+
+// WithPort configures the GRPC tunnel server
+// to listen on a given port.
+func WithPort(p int) ServerOption {
+	return func(opt *ServerConfig) error {
+		opt.port = p
+		return nil
+	}
+}
+
+// WithTLS configures the GRPC tunnel server
+// to use TLS
+func WithTLS(cert, key string) ServerOption {
+	return func(opt *ServerConfig) error {
+		opt.TLS = true
+		opt.certFile = cert
+		opt.keyFile = key
+		return nil
+	}
+}
+
+// WithLogger sets the logger to be used by the server.
+// if not set, output will be discarded
+func WithLogger(l log.FieldLogger) ServerOption {
+	return func(opt *ServerConfig) error {
+		opt.log = l
+		return nil
+	}
+}
+
+// ServerOption is an option able to be configured
+type ServerOption func(*ServerConfig) error
+
+// ServerConfig is a config object used to
+// configure a GRPC Server. ServerOption should
+// be used to modify this
+type ServerConfig struct {
+	port     int
+	TLS      bool
+	keyFile  string
+	log      log.FieldLogger
+	certFile string
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"strings"
 
@@ -115,6 +116,9 @@ func readConn(session *common.Session, sessions chan<- *common.Session) {
 
 		session.Lock.Lock()
 		if err != nil {
+			if err == io.EOF {
+				return
+			}
 			log.WithError(err).WithField("session", session.Id).Infof("failed to read from conn")
 
 			// setting Open to false triggers SendData() to

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -7,8 +7,6 @@ import (
 	"net"
 	"strings"
 
-	"io"
-
 	"github.com/google/uuid"
 	"github.com/omrikiei/ktunnel/pkg/common"
 	pb "github.com/omrikiei/ktunnel/tunnel_pb"
@@ -117,15 +115,14 @@ func readConn(session *common.Session, sessions chan<- *common.Session) {
 
 		session.Lock.Lock()
 		if err != nil {
-			if err == io.EOF {
-				return
-			}
 			log.WithError(err).WithField("session", session.Id).Infof("failed to read from conn")
 
 			// setting Open to false triggers SendData() to
 			// send ShouldClose
 			session.Open = false
 		}
+
+		// write the data to the session buffer, if we have data
 		if br > 0 {
 			session.Buf.Write(buff[0:br])
 		}


### PR DESCRIPTION
**What this PR does**: This PR fixes the issues found in https://github.com/omrikiei/ktunnel/issues/24, and some struggles I ran into when trying to use this as a library with my own project. The main highlights are:

* Uses `context` for cancellation in both the client and server.
* Uses a single static buffer on the session, and then reads in chunks from each side for TCP listeners instead of a dynamically resized buffer. Right now the limit is around 3MB, which is below the 4MB limit.
* Uses functional args for configuration to allow for easier updates to these interfaces
* Allows the user to pass their own logger, with the default being a logrus logger that uses `ioutil.Discard` as the out.
* Few misc adjustments around handling TCP client connections, closing, and etc.

**What's left?**

This is what is keeping this in draft currently:

 * [ ] Update everything in `cmd/` to support the new functional args interface, and pass in a logger.
 * [ ] A quick once over to make sure I didn't miss anything, I did this incrementally, and a lot of times was pushing just to be able to build a docker image 😆 

**Notes for my reviewer**: I'm happy to split this into chunks, if that's wanted!