### PR TITLE
Enhance Service Discovery for exposed service/pod

### DIFF
--- a/pkg/k8s/injector.go
+++ b/pkg/k8s/injector.go
@@ -32,7 +32,7 @@ func injectToDeployment(o *appsv1.Deployment, c *apiv1.Container, image string, 
 func InjectSidecar(namespace, objectName *string, port *int, image string, readyChan chan<- bool) (bool, error) {
 	log.Infof("Injecting tunnel sidecar to %s/%s", *namespace, *objectName)
 	getClients(namespace)
-	co := newContainer(*port, image)
+	co := newContainer(*port, image, []apiv1.ContainerPort{})
 	creationTime := time.Now().Add(-1 * time.Second)
 	obj, err := deploymentsClient.Get(context.Background(), *objectName, metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
This PR adds:

* a better exposition method for the Service (it's labeled with the same labels than the Pod)
* naming on the Service ports, based on their scheme and port number (tcp-1234, udp-3456).
* actual port exposition on the containers of the Deployment (expose) method. Hence, ports can be directly discovered/used on the Pods if required.

Should also resolve #43 