### PR TITLE
Use current time when waiting for injector to be ready

### DIFF
--- a/cmd/inject.go
+++ b/cmd/inject.go
@@ -75,7 +75,12 @@ ktunnel inject deploymeny mydeployment 3306 6379
 		}()
 
 		log.Info("Waiting for deployment to be ready")
-		<-readyChan
+		success := <-readyChan
+		if !success {
+			sigs <- syscall.SIGQUIT
+			<-done
+			return
+		}
 
 		// port-Forward
 		strPort := strconv.FormatInt(int64(port), 10)

--- a/pkg/k8s/common.go
+++ b/pkg/k8s/common.go
@@ -328,19 +328,26 @@ func watchForReady(deploymentName *string, readyChan chan<- bool) {
 		for {
 			deployment, err := deploymentsClient.Get(context.Background(), *deploymentName, metav1.GetOptions{})
 			if err != nil {
-				log.Error(err)
-				os.Exit(1)
+				log.Errorf("Failed fetching deployment; %v", err)
+				readyChan <- false
+				return
 			}
 			msg, done, err := deploymentStatus(deployment)
-			print(msg)
+
 			if done {
+				print("\n")
+				log.Info(msg)
 				readyChan <- true
 				return
 			} else if err != nil {
-				log.Error(err)
-				os.Exit(1)
+				print("\n")
+				log.Errorf("Failed deploying tunnel sidecar; %v", err)
+				readyChan <- false
+				return
+			} else {
+				print(".")
+				time.Sleep(time.Millisecond * 300)
 			}
-			time.Sleep(time.Millisecond * 300)
 		}
 	}()
 }


### PR DESCRIPTION
Re: #47

I'm not too familiar with the k8 api, so I don't know if there is a way to get the updated time for the deployment, but the creation time did not appear to be changing when updated. Using the current time seems to achieve the desired effect. 