### PR TITLE
Fix error handling for ProgressDeadlineExceeded

### DIFF
--- a/pkg/k8s/common.go
+++ b/pkg/k8s/common.go
@@ -19,6 +19,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	v1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	v12 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -323,30 +324,63 @@ func getPortForwardUrl(config *rest.Config, namespace string, podName string) *u
 	}
 }
 
-func watchForReady(deploymentName *string, readyChan chan<- bool) {
+func watchForReady(deployment *appsv1.Deployment, readyChan chan<- bool) {
 	go func() {
+		lastMsg := ""
+
+		maxUnavailable := deployment.Spec.Strategy.RollingUpdate.MaxUnavailable.IntValue()
+		if maxUnavailable > 0 {
+			log.Warnf("RollingUpdate.MaxUnavailable: %v. This may prevent deployment failures from being detected. Set to 0 to ensure ProgressDeadlineInSeconds is enforced.", maxUnavailable)
+		}
+
+		progressDeadlineSeconds := int64(*deployment.Spec.ProgressDeadlineSeconds)
+		log.Infof("ProgressDeadlineInSeconds is currently %vs. It may take this long to detect a deployment failure.", progressDeadlineSeconds)
+		progressDeadlineSeconds += 5
+
+		watch, err := deploymentsClient.Watch(context.Background(), metav1.ListOptions{
+			LabelSelector:  labels.Set(deployment.Labels).String(),
+			TimeoutSeconds: &progressDeadlineSeconds,
+		})
+
+		if err != nil {
+			log.Error(err)
+			readyChan <- false
+			return
+		}
+		resultChan := watch.ResultChan()
+
 		for {
-			deployment, err := deploymentsClient.Get(context.Background(), *deploymentName, metav1.GetOptions{})
-			if err != nil {
-				log.Errorf("Failed fetching deployment; %v", err)
+			event, ok := <-resultChan
+			if !ok {
+				log.Error("Timeout exceeded waiting for deployment to be ready")
+				watch.Stop()
 				readyChan <- false
 				return
 			}
+
+			deployment, ok := event.Object.(*appsv1.Deployment)
+			if !ok {
+				log.Warn("Watch Received Not Deployment")
+				continue
+			}
+
 			msg, done, err := deploymentStatus(deployment)
 
 			if done {
-				print("\n")
+				watch.Stop()
 				log.Info(msg)
 				readyChan <- true
 				return
 			} else if err != nil {
-				print("\n")
+				watch.Stop()
 				log.Errorf("Failed deploying tunnel sidecar; %v", err)
 				readyChan <- false
 				return
 			} else {
-				print(".")
-				time.Sleep(time.Millisecond * 300)
+				if lastMsg != msg {
+					log.Info(msg)
+				}
+				lastMsg = msg
 			}
 		}
 	}()
@@ -354,8 +388,18 @@ func watchForReady(deploymentName *string, readyChan chan<- bool) {
 
 func deploymentStatus(deployment *appsv1.Deployment) (string, bool, error) {
 	if deployment.Generation <= deployment.Status.ObservedGeneration {
+		updateTime := time.Now()
+		for _, field := range deployment.ManagedFields {
+			if field.Manager == "kube-controller-manager" && field.Operation == "Update" {
+				updateTime = field.Time.Time
+			}
+		}
+
 		for _, cond := range deployment.Status.Conditions {
-			if cond.Type == "ProgressDeadlineExceeded" {
+			if cond.Type == appsv1.DeploymentProgressing &&
+				cond.Status == apiv1.ConditionFalse &&
+				cond.Reason == "ProgressDeadlineExceeded" &&
+				cond.LastUpdateTime.Time.After(updateTime) {
 				return "", false, fmt.Errorf("deployment %q exceeded its progress deadline", deployment.Name)
 			}
 		}

--- a/pkg/k8s/injector.go
+++ b/pkg/k8s/injector.go
@@ -14,7 +14,7 @@ import (
 func injectToDeployment(o *appsv1.Deployment, c *apiv1.Container, image string, readyChan chan<- bool) (bool, error) {
 	if hasSidecar(o.Spec.Template.Spec, image) {
 		log.Warn(fmt.Sprintf("%s already injected to the deplyoment", image))
-		readyChan <- true
+		watchForReady(o, readyChan)
 		return true, nil
 	}
 	o.Spec.Template.Spec.Containers = append(o.Spec.Template.Spec.Containers, *c)
@@ -26,7 +26,7 @@ func injectToDeployment(o *appsv1.Deployment, c *apiv1.Container, image string, 
 	if updateErr != nil {
 		return false, updateErr
 	}
-	watchForReady(&u.Name, readyChan)
+	watchForReady(u, readyChan)
 	return true, nil
 }
 
@@ -88,6 +88,6 @@ func RemoveSidecar(namespace, objectName *string, image string, readyChan chan<-
 	if updateErr != nil {
 		return false, updateErr
 	}
-	watchForReady(&u.Name, readyChan)
+	watchForReady(u, readyChan)
 	return true, nil
 }


### PR DESCRIPTION
HI @omrikiei,

The primary reason for this change is to fix a bug detecting `ProgressDeadlineExceeded`.  I was accidentally checking for that in the Type when it should have been in the Reason.

While I was testing it out (Deployments failing because the v1.3.8 image doesn't exist yet), I noticed some inconsistent behavior that led to a bit of refactoring.

It appears that if you have `maxUnavailable: 1` in your Deployment yaml, it can cause issues where `ProgressDeadlineExceeded` is never raised. I added a warning to notify since it is something that can be handled in the yaml.

The other change was getting the most recent update time from the ManagedFields.  This might have been what we were looking for all along with the original `waitForReady` method, but I didn't investigate to thoroughly.  Before adding it the rollback would sometimes exit with the `ProgressDeadlineExceeded` error still in the status from the previous failed deployment.

Let me know what you think. Sorry to complicate things.