### PR TITLE
Load the kubeconfig using the DefaultLoader rules

### DIFF
--- a/pkg/k8s/common.go
+++ b/pkg/k8s/common.go
@@ -56,12 +56,16 @@ var Verbose = false
 
 func getKubeConfig() *rest.Config {
 	o.Do(func() {
+		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+
 		kconfig := os.Getenv("KUBECONFIG")
 		if home := homedir.HomeDir(); kconfig == "" && home != "" {
 			kconfig = filepath.Join(home, ".kube", "config")
+			loadingRules.ExplicitPath = kconfig
 		}
 
-		config, err := clientcmd.BuildConfigFromFlags("", kconfig)
+		config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			loadingRules, &clientcmd.ConfigOverrides{}).ClientConfig()
 		if err != nil {
 			log.Errorf("Failed getting kubernetes config: %v", err)
 		}


### PR DESCRIPTION
Fixes https://github.com/omrikiei/ktunnel/issues/57

**Changes:**
Use the default loader rules instead of trying to load file directly.
This is needed if we specify multiple files in KUBE_CONFIG env variable

**Tests:**
Verified ktunnel launches successfully without crashing