### PR TITLE
reusing existing deployment and service for creating tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This will allow pods in the cluster to access your local web app (listening on p
 http (i.e kubernetes applications can send requests to myapp:8000)
 ```bash
 ktunnel expose myapp 80:8000
+ktunnel expose myapp 80:8000 -r #for reconnecting to existing deployment & service
 ```
 
 ### Inject to an existing deployment

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This will allow pods in the cluster to access your local web app (listening on p
 http (i.e kubernetes applications can send requests to myapp:8000)
 ```bash
 ktunnel expose myapp 80:8000
-ktunnel expose myapp 80:8000 -r #for reconnecting to existing deployment & service
+ktunnel expose myapp 80:8000 -r #deployment & service will be reused if exists or they will be created
 ```
 
 ### Inject to an existing deployment

--- a/cmd/expose.go
+++ b/cmd/expose.go
@@ -15,6 +15,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var ReConnect bool
+
 var exposeCmd = &cobra.Command{
 	Use:   "expose [flags] SERVICE_NAME [ports]",
 	Short: "Expose local machine as a service on the kubernetes cluster",
@@ -24,6 +26,8 @@ var exposeCmd = &cobra.Command{
 	Example: `
 # Expose a local application running on port 8000 via http
 ktunnel expose kewlapp 80:8000
+
+ktunnel expose kewlapp 80:8000 -r
 			  
 # Expose a local redis server
 ktunnel expose redis 6379
@@ -39,7 +43,7 @@ ktunnel expose redis 6379
 		// Create service and deployment
 		svcName, ports := args[0], args[1:]
 		readyChan := make(chan bool, 1)
-		err := k8s.ExposeAsService(&Namespace, &svcName, port, Scheme, ports, ServerImage, readyChan)
+		err := k8s.ExposeAsService(&Namespace, &svcName, port, Scheme, ports, ServerImage, ReConnect, readyChan)
 		if err != nil {
 			log.Fatalf("Failed to expose local machine as a service: %v", err)
 		}
@@ -54,9 +58,11 @@ ktunnel expose redis 6379
 				_ = <-sigs
 				log.Info("Got exit signal, closing client tunnels and removing k8s objects")
 				cancel()
-				err := k8s.TeardownExposedService(Namespace, svcName)
-				if err != nil {
-					log.Errorf("Failed deleting k8s objects: %s", err)
+				if !ReConnect {
+					err := k8s.TeardownExposedService(Namespace, svcName)
+					if err != nil {
+						log.Errorf("Failed deleting k8s objects: %s", err)
+					}
 				}
 				done <- true
 			})
@@ -107,5 +113,6 @@ func init() {
 	exposeCmd.Flags().StringVarP(&ServerHostOverride, "server-host-override", "o", "", "Server name use to verify the hostname returned by the TLS handshake")
 	exposeCmd.Flags().StringVarP(&Namespace, "namespace", "n", "default", "Namespace")
 	exposeCmd.Flags().StringVarP(&ServerImage, "server-image", "i", fmt.Sprintf("%s:v%s", k8s.Image, version), "Ktunnel server image to use")
+	exposeCmd.Flags().BoolVarP(&ReConnect, "reconnect", "r", false, "reconnect the existing deploayment and service (tunnel)")
 	rootCmd.AddCommand(exposeCmd)
 }

--- a/pkg/k8s/exposer.go
+++ b/pkg/k8s/exposer.go
@@ -2,13 +2,20 @@ package k8s
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/omrikiei/ktunnel/pkg/common"
 	log "github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
 	v12 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var supportedSchemes = map[string]v12.Protocol{
@@ -16,7 +23,7 @@ var supportedSchemes = map[string]v12.Protocol{
 	"udp": v12.ProtocolUDP,
 }
 
-func ExposeAsService(namespace, name *string, tunnelPort int, scheme string, rawPorts []string, image string, readyChan chan<- bool) error {
+func ExposeAsService(namespace, name *string, tunnelPort int, scheme string, rawPorts []string, image string, ReConnect bool, readyChan chan<- bool) error {
 	getClients(namespace)
 
 	ports := make([]v12.ServicePort, len(rawPorts))
@@ -52,22 +59,69 @@ func ExposeAsService(namespace, name *string, tunnelPort int, scheme string, raw
 	deployment := newDeployment(*namespace, *name, tunnelPort, image, ctrPorts)
 
 	service := newService(*namespace, *name, ports)
-	d, err := deploymentsClient.Create(context.Background(), deployment, v1.CreateOptions{
-		TypeMeta:     v1.TypeMeta{},
-		DryRun:       nil,
-		FieldManager: "",
-	})
-	if err != nil {
-		return err
+
+	var d *appsv1.Deployment
+	var err error
+	deploymentCreated := false
+	_, err = deploymentsClient.Get(context.Background(), *name, v1.GetOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		d, err = deploymentsClient.Create(context.Background(), deployment, v1.CreateOptions{
+			TypeMeta:     v1.TypeMeta{},
+			DryRun:       nil,
+			FieldManager: "",
+		})
+		if err != nil {
+			return err
+		}
 	}
-	newSvc, err := svcClient.Create(context.Background(), service, v1.CreateOptions{
-		TypeMeta:     v1.TypeMeta{},
-		DryRun:       nil,
-		FieldManager: "",
-	})
-	if err != nil {
-		return err
+	if !deploymentCreated && ReConnect {
+		patch, err := json.Marshal(deployment)
+		if err != nil {
+			return err
+		}
+		d, err = deploymentsClient.Patch(context.Background(), *name, types.MergePatchType, patch, v1.PatchOptions{
+			TypeMeta:     v1.TypeMeta{},
+			DryRun:       nil,
+			FieldManager: "",
+		})
+		time.Sleep(time.Millisecond * 300)
+		if err != nil {
+			return err
+		}
 	}
+
+	var newSvc *v12.Service
+	serviceCreated := false
+	_, err = svcClient.Get(context.Background(), *name, v1.GetOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+
+		newSvc, err = svcClient.Create(context.Background(), service, v1.CreateOptions{
+			TypeMeta:     v1.TypeMeta{},
+			DryRun:       nil,
+			FieldManager: "",
+		})
+
+		if err != nil {
+			return err
+		}
+		serviceCreated = true
+	}
+	if !serviceCreated && ReConnect {
+		patch, err := json.Marshal(service)
+		if err != nil {
+			return err
+		}
+		newSvc, err = svcClient.Patch(context.Background(), *name, types.MergePatchType, patch, v1.PatchOptions{
+			TypeMeta:     v1.TypeMeta{},
+			DryRun:       nil,
+			FieldManager: "",
+		})
+		time.Sleep(time.Millisecond * 300)
+		if err != nil {
+			return err
+		}
+	}
+
 	log.Infof("Exposed service's cluster ip is: %s", newSvc.Spec.ClusterIP)
 	waitForReady(name, d.GetCreationTimestamp().Time, *deployment.Spec.Replicas, readyChan)
 	return nil

--- a/pkg/k8s/exposer.go
+++ b/pkg/k8s/exposer.go
@@ -73,6 +73,7 @@ func ExposeAsService(namespace, name *string, tunnelPort int, scheme string, raw
 		if err != nil {
 			return err
 		}
+		deploymentCreated = true
 	}
 	if !deploymentCreated && ReConnect {
 		patch, err := json.Marshal(deployment)


### PR DESCRIPTION
this can useful if user just want use same service ip as it may have configured already in some other deployments/applications to use. 

deleting and recreating service will change ip address for service which may not be desired for few users (for us).