### PR TITLE
Add securityContext to make container run as non-root user.

### DIFF
--- a/pkg/k8s/common.go
+++ b/pkg/k8s/common.go
@@ -148,6 +148,7 @@ func newContainer(port int, image string, containerPorts []apiv1.ContainerPort, 
 	cpuLimit.SetMilli(int64(1000))
 	memRequest.SetScaled(int64(100), resource.Mega)
 	memLimit.SetScaled(int64(1), resource.Giga)
+	containerUid := int64(1000)
 
 	return &apiv1.Container{
 		Name:    "ktunnel",
@@ -164,6 +165,9 @@ func newContainer(port int, image string, containerPorts []apiv1.ContainerPort, 
 				"cpu":    cpuLimit,
 				"memory": memLimit,
 			},
+		},
+		SecurityContext: &apiv1.SecurityContext{
+			RunAsUser: &containerUid,
 		},
 	}
 }


### PR DESCRIPTION
Image appears to work fine running as non-root user.