### PR TITLE
fix: add arm64 binaries to krew manifest bot template

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -19,9 +19,21 @@ spec:
     bin: ktunnel
   - selector:
       matchLabels:
+        os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/omrikiei/ktunnel/releases/download/{{ .TagName }}/ktunnel_{{ slice .TagName 1 }}_Darwin_arm64.tar.gz" .TagName }}
+    bin: ktunnel
+  - selector:
+      matchLabels:
         os: linux
         arch: amd64
     {{addURIAndSha "https://github.com/omrikiei/ktunnel/releases/download/{{ .TagName }}/ktunnel_{{ slice .TagName 1 }}_Linux_x86_64.tar.gz" .TagName }}
+    bin: ktunnel
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    {{addURIAndSha "https://github.com/omrikiei/ktunnel/releases/download/{{ .TagName }}/ktunnel_{{ slice .TagName 1 }}_Linux_arm64.tar.gz" .TagName }}
     bin: ktunnel
   - selector:
       matchLabels:
@@ -29,3 +41,10 @@ spec:
         arch: amd64
     {{addURIAndSha "https://github.com/omrikiei/ktunnel/releases/download/{{ .TagName }}/ktunnel_{{ slice .TagName 1 }}_Windows_x86_64.tar.gz" .TagName }}
     bin: ktunnel.exe
+  - selector:
+      matchLabels:
+        os: windows
+        arch: arm64
+    {{addURIAndSha "https://github.com/omrikiei/ktunnel/releases/download/{{ .TagName }}/ktunnel_{{ slice .TagName 1 }}_Windows_arm64.tar.gz" .TagName }}
+    bin: ktunnel.exe
+


### PR DESCRIPTION
I recently switched to an ARM based MacBook, and noticed that installing ktunnel via krew failed.
This PR should add your existing ARM binaries to the krew index.

---

Unrelated to this PR: You mentioned in #75 that you want to switch to a different container registry. Would you be open to accept a PR to switch to ghcr.io?