### PR TITLE
Add service type option to expose command

### DIFF
--- a/cmd/expose.go
+++ b/cmd/expose.go
@@ -18,6 +18,7 @@ import (
 
 var Reuse bool
 var Force bool
+var ServiceType string
 var NodeSelectorTags []string
 
 var exposeCmd = &cobra.Command{
@@ -64,7 +65,7 @@ ktunnel expose redis 6379
 			}
 		}
 
-		err := k8s.ExposeAsService(&Namespace, &svcName, port, Scheme, ports, ServerImage, Reuse, readyChan, nodeSelectorTags, CertFile, KeyFile)
+		err := k8s.ExposeAsService(&Namespace, &svcName, port, Scheme, ports, ServerImage, Reuse, readyChan, nodeSelectorTags, CertFile, KeyFile, ServiceType)
 		if err != nil {
 			log.Fatalf("Failed to expose local machine as a service: %v", err)
 		}
@@ -140,6 +141,7 @@ func init() {
 	exposeCmd.Flags().StringVarP(&ServerImage, "server-image", "i", fmt.Sprintf("%s:v%s", k8s.Image, version), "Ktunnel server image to use")
 	exposeCmd.Flags().StringVar(&CertFile, "cert", "", "TLS certificate file")
 	exposeCmd.Flags().StringVar(&KeyFile, "key", "", "TLS key file")
+	exposeCmd.Flags().StringVar(&ServiceType, "service-type", "ClusterIP", "exposed service type (ClusterIP, NodePort, LoadBalancer or ExternalName)")
 	exposeCmd.Flags().BoolVarP(&Reuse, "reuse", "r", false, "delete k8s objects before expose")
 	exposeCmd.Flags().BoolVarP(&Force, "force", "f", false, "deployment & service will be removed before")
 	exposeCmd.Flags().StringSliceVarP(&NodeSelectorTags, "node-selector-tags", "q", []string{}, "tag and value seperated by the '=' character (i.e kubernetes.io/os=linux)")

--- a/docs/ktunnel_expose.md
+++ b/docs/ktunnel_expose.md
@@ -36,6 +36,7 @@ ktunnel expose redis 6379
   -s, --scheme string                 Connection scheme (default "tcp")
   -o, --server-host-override string   Server name use to verify the hostname returned by the TLS handshake
   -i, --server-image string           Ktunnel server image to use (default "quay.io/omrikiei/ktunnel:v1.4.4")
+  --service-type string           exposed service type (ClusterIP, NodePort, LoadBalancer or ExternalName) (default "ClusterIP")
 ```
 
 ### Options inherited from parent commands

--- a/pkg/k8s/common.go
+++ b/pkg/k8s/common.go
@@ -211,7 +211,7 @@ func newDeployment(namespace, name string, port int, image string, ports []apiv1
 	}
 }
 
-func newService(namespace, name string, ports []apiv1.ServicePort) *apiv1.Service {
+func newService(namespace, name string, ports []apiv1.ServicePort, serviceType apiv1.ServiceType) *apiv1.Service {
 	return &apiv1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "Service",
@@ -226,6 +226,7 @@ func newService(namespace, name string, ports []apiv1.ServicePort) *apiv1.Servic
 		},
 		Spec: apiv1.ServiceSpec{
 			Ports: ports,
+			Type: serviceType,
 			Selector: map[string]string{
 				"app.kubernetes.io/name":     name,
 				"app.kubernetes.io/instance": name,

--- a/pkg/k8s/exposer.go
+++ b/pkg/k8s/exposer.go
@@ -23,7 +23,7 @@ var supportedSchemes = map[string]v12.Protocol{
 	"udp": v12.ProtocolUDP,
 }
 
-func ExposeAsService(namespace, name *string, tunnelPort int, scheme string, rawPorts []string, image string, Reuse bool, readyChan chan<- bool, nodeSelectorTags map[string]string, cert, key string) error {
+func ExposeAsService(namespace, name *string, tunnelPort int, scheme string, rawPorts []string, image string, Reuse bool, readyChan chan<- bool, nodeSelectorTags map[string]string, cert, key string, serviceType string) error {
 	getClients(namespace)
 
 	ports := make([]v12.ServicePort, len(rawPorts))
@@ -58,7 +58,7 @@ func ExposeAsService(namespace, name *string, tunnelPort int, scheme string, raw
 
 	deployment := newDeployment(*namespace, *name, tunnelPort, image, ctrPorts, nodeSelectorTags, cert, key)
 
-	service := newService(*namespace, *name, ports)
+	service := newService(*namespace, *name, ports, v12.ServiceType(serviceType))
 
 	var d *appsv1.Deployment
 	var err error


### PR DESCRIPTION
Hi!

This PR allows the ktunnel to support any service type when using `expose command`.

Specifically, the ALB only supports `NodePort` or `LoadBalancer` if it uses.
Now I deal with the above problem by updating the service resource using `kubectl edit command`.

Therefore, I would like to optionally set the service type option when using the expose command. 

## Example

```bash
ktunnel expose myapp 80:8000 --service-type=NodePort
```

## Ref: 
- https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html
- https://pkg.go.dev/k8s.io/api@v0.25.4/core/v1#ServiceSpec