### PR TITLE
Start the session immediately in the read loop

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -125,6 +125,7 @@ func ReceiveData(conf *Config, stream pb.Tunnel_InitTunnelServer) {
 
 func readConn(ctx context.Context, conf *Config, session *common.Session, sessions chan<- *common.Session) {
 	conf.log.WithField("session", session.Id.String()).Info("new connection")
+	sessions <- session
 
 	for {
 


### PR DESCRIPTION
Upon starting the read loop, immediately send the current session to initiate the connection with the remote end, rather than waiting for the first data packet from the pod.

Fixes #60 