### PR TITLE
Fix race condition in deployment ready state detection

### DIFF
--- a/pkg/k8s/common.go
+++ b/pkg/k8s/common.go
@@ -98,31 +98,6 @@ func getAllPods(namespace *string) (*apiv1.PodList, error) {
 	return pods, nil
 }
 
-func waitForReady(name *string, ti time.Time, numPods int32, readyChan chan<- bool) {
-	go func() {
-		for {
-			print(".")
-			count := int32(0)
-			pods, err := podsClient.List(context.Background(), metav1.ListOptions{})
-			if err != nil {
-				log.Error(err)
-				os.Exit(1)
-			}
-			for _, p := range pods.Items {
-				if strings.HasPrefix(p.Name, *name) && p.CreationTimestamp.After(ti.Add(-time.Second)) && p.Status.Phase == apiv1.PodRunning {
-					count += 1
-				}
-				if count == numPods {
-					readyChan <- true
-					println()
-					return
-				}
-			}
-			time.Sleep(time.Millisecond * 300)
-		}
-	}()
-}
-
 func hasSidecar(podSpec apiv1.PodSpec, image string) bool {
 	for _, c := range podSpec.Containers {
 		if c.Image == image {

--- a/pkg/k8s/exposer.go
+++ b/pkg/k8s/exposer.go
@@ -137,7 +137,7 @@ func ExposeAsService(namespace, name *string, tunnelPort int, scheme string, raw
 	}
 
 	log.Infof("Exposed service's cluster ip is: %s", newSvc.Spec.ClusterIP)
-	waitForReady(name, d.GetCreationTimestamp().Time, *deployment.Spec.Replicas, readyChan)
+	watchForReady(deployment, readyChan)
 	return nil
 }
 


### PR DESCRIPTION
When a deployment is updated (using `--reuse`), and if `waitForReady()` is invoked before k8s actually started to schedule pods, then it will return immediately and eventually fail with:

```
failed parsing session uuid from stream, skipping  error="invalid UUID length: 0" session=
```

Using `watchForReady()` instead ensure that the deployment actually reach a stable state.