### PR TITLE
feat: Allowing to forward other hostnames than localhost (#108)

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -44,7 +44,8 @@ func (s *Session) Close() {
 
 type RedirectRequest struct {
 	Source int32
-	Target int32
+	TargetHost string
+	TargetPort int32
 }
 
 func NewSession(conn net.Conn) *Session {
@@ -103,7 +104,8 @@ func ParsePorts(s string) (*RedirectRequest, error) {
 		}
 		return &RedirectRequest{
 			Source: int32(p),
-			Target: int32(p),
+			TargetHost: "localhost",
+			TargetPort: int32(p),
 		}, nil
 	}
 	if len(raw) == 2 {
@@ -117,7 +119,23 @@ func ParsePorts(s string) (*RedirectRequest, error) {
 		}
 		return &RedirectRequest{
 			Source: int32(s),
-			Target: int32(t),
+			TargetHost: "localhost",
+			TargetPort: int32(t),
+		}, nil
+	}
+	if len(raw) == 3 {
+		s, err := strconv.ParseInt(raw[0], 10, 32)
+		if err != nil {
+			return nil, errors.New(fmt.Sprintf("failed to parse port %s, %v", raw[0], err))
+		}
+		t, err := strconv.ParseInt(raw[2], 10, 32)
+		if err != nil {
+			return nil, errors.New(fmt.Sprintf("failed to parse port %s, %v", raw[1], err))
+		}
+		return &RedirectRequest{
+			Source: int32(s),
+			TargetHost: raw[1],
+			TargetPort: int32(t),
 		}, nil
 	}
 	return nil, errors.New(fmt.Sprintf("Error, bad tunnel format: %s", s))


### PR DESCRIPTION
Allowing to forward other hosts than `localhost` to Kubernetes.

## Usage
- `ktunnel expose mynginx 8080:nginx:80` to forward all requests targeted at `mynginx:8080` inside K8s to another host `nginx:80`.
- If no hostname is provided, it uses localhost to preserve the current behaviour.

## Testing
Tested it in combination with docker-compose to create a reproducable testing environment.

*Dockerfile*:
```Dockerfile
FROM dtzar/helm-kubectl:latest
COPY test/ktunnel /usr/local/bin
```

*docker-compose.yml*:
```yml
version: '3.3'
services:
  tunnel: # Creates K8s service mynginx:8080 and forwards all traffic to nginx:80
    build: .
    volumes:
      - /home/xxx/.kube/config:/root/.kube/config:ro
    command:
      - 'bash'
      - '-c'
      - 'ktunnel expose mynginx 8080:nginx:80'
  nginx: # Runs on Port 80
    image: nginx
```

Hi @omrikiei,
I tried my luck implementing #108. Could you have a look on this MR? Always open for change requests 😃.

Closes #108