### PR TITLE
Add istio/envoy grpc-web support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+## What does this fork do?
+
+It simply adds grpc-web to the list of supported schemes for the exposer. grpc-web is on the TCP protocol, so the only difference in the resulting deployment is that the service exposed will have its port name prefixed by `grpc-web`. This is especially useful using grpc-web with istio as the envoy proxy will know to convert an http request to grpc.
+
+
 <p align="center">
   <a href="" rel="noopener">
  <img width=200px height=100px src="./ktunnel-logo/cover.png" alt="Ktunnel logo"></a>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-## What does this fork do?
-
-It simply adds grpc-web to the list of supported schemes for the exposer. grpc-web is on the TCP protocol, so the only difference in the resulting deployment is that the service exposed will have its port name prefixed by `grpc-web`. This is especially useful using grpc-web with istio as the envoy proxy will know to convert an http request to grpc.
-
-
 <p align="center">
   <a href="" rel="noopener">
  <img width=200px height=100px src="./ktunnel-logo/cover.png" alt="Ktunnel logo"></a>

--- a/pkg/k8s/exposer.go
+++ b/pkg/k8s/exposer.go
@@ -21,6 +21,7 @@ import (
 var supportedSchemes = map[string]v12.Protocol{
 	"tcp": v12.ProtocolTCP,
 	"udp": v12.ProtocolUDP,
+	"grpc-web": v12.ProtocolTCP,
 }
 
 func ExposeAsService(namespace, name *string, tunnelPort int, scheme string, rawPorts []string, image string, Reuse bool, readyChan chan<- bool, nodeSelectorTags map[string]string, cert, key string, serviceType string, kubecontext *string) error {


### PR DESCRIPTION
This PR simply adds grpc-web to the list of supported schemes for the exposer. grpc-web is on the TCP protocol, so the only difference in the resulting deployment is that the service exposed will have its port name prefixed by grpc-web. This is especially useful using grpc-web with istio as the envoy proxy will know to convert an http request to grpc.