### PR TITLE
feat: enable setting custom labels and container portname and deployment only mode

### DIFF
--- a/cmd/expose.go
+++ b/cmd/expose.go
@@ -55,9 +55,9 @@ ktunnel expose redis 6379
 			parsed := strings.Split(tag, "=")
 			if len(parsed) != 2 {
 				log.Errorf("failed to parse node selector tag: %v", tag)
-			} else {
-				nodeSelectorTags[parsed[0]] = parsed[1]
+				continue
 			}
+			nodeSelectorTags[parsed[0]] = parsed[1]
 		}
 
 		deploymentLabels := map[string]string{}
@@ -65,9 +65,9 @@ ktunnel expose redis 6379
 			parsed := strings.Split(label, "=")
 			if len(parsed) != 2 {
 				log.Errorf("failed to parse deployment label: %v", label)
-			} else {
-				deploymentLabels[parsed[0]] = parsed[1]
+				continue
 			}
+			deploymentLabels[parsed[0]] = parsed[1]
 		}
 
 		if Force {

--- a/cmd/expose.go
+++ b/cmd/expose.go
@@ -18,8 +18,11 @@ import (
 
 var Reuse bool
 var Force bool
+var DeploymentOnly bool
+var PortName string
 var ServiceType string
 var NodeSelectorTags []string
+var DeploymentLabels []string
 
 var exposeCmd = &cobra.Command{
 	Use:   "expose [flags] SERVICE_NAME [ports]",
@@ -50,7 +53,6 @@ ktunnel expose redis 6379
 		nodeSelectorTags := map[string]string{}
 		for _, tag := range NodeSelectorTags {
 			parsed := strings.Split(tag, "=")
-			log.Error(parsed)
 			if len(parsed) != 2 {
 				log.Errorf("failed to parse node selector tag: %v", tag)
 			} else {
@@ -58,14 +60,24 @@ ktunnel expose redis 6379
 			}
 		}
 
+		deploymentLabels := map[string]string{}
+		for _, label := range DeploymentLabels {
+			parsed := strings.Split(label, "=")
+			if len(parsed) != 2 {
+				log.Errorf("failed to parse deployment label: %v", label)
+			} else {
+				deploymentLabels[parsed[0]] = parsed[1]
+			}
+		}
+
 		if Force {
-			err := k8s.TeardownExposedService(Namespace, svcName, &KubeContext)
+			err := k8s.TeardownExposedService(Namespace, svcName, &KubeContext, DeploymentOnly)
 			if err != nil {
 				log.Infof("Force delete: Failed deleting k8s objects: %s", err)
 			}
 		}
 
-		err := k8s.ExposeAsService(&Namespace, &svcName, port, Scheme, ports, ServerImage, Reuse, readyChan, nodeSelectorTags, CertFile, KeyFile, ServiceType, &KubeContext)
+		err := k8s.ExposeAsService(&Namespace, &svcName, port, Scheme, ports, PortName, ServerImage, Reuse, DeploymentOnly, readyChan, nodeSelectorTags, deploymentLabels, CertFile, KeyFile, ServiceType, &KubeContext)
 		if err != nil {
 			log.Fatalf("Failed to expose local machine as a service: %v", err)
 		}
@@ -85,7 +97,7 @@ ktunnel expose redis 6379
 				}
 				cancel()
 				if !Reuse {
-					err := k8s.TeardownExposedService(Namespace, svcName, &KubeContext)
+					err := k8s.TeardownExposedService(Namespace, svcName, &KubeContext, DeploymentOnly)
 					if err != nil {
 						log.Errorf("Failed deleting k8s objects: %s", err)
 					}
@@ -143,8 +155,11 @@ func init() {
 	exposeCmd.Flags().StringVar(&CertFile, "cert", "", "TLS certificate file")
 	exposeCmd.Flags().StringVar(&KeyFile, "key", "", "TLS key file")
 	exposeCmd.Flags().StringVar(&ServiceType, "service-type", "ClusterIP", "exposed service type (ClusterIP, NodePort, LoadBalancer or ExternalName)")
+	exposeCmd.Flags().StringVar(&PortName, "portname", "", "specify container port name")
 	exposeCmd.Flags().BoolVarP(&Reuse, "reuse", "r", false, "delete k8s objects before expose")
 	exposeCmd.Flags().BoolVarP(&Force, "force", "f", false, "deployment & service will be removed before")
+	exposeCmd.Flags().BoolVarP(&DeploymentOnly, "deployment-only", "d", false, "create only deployment")
 	exposeCmd.Flags().StringSliceVarP(&NodeSelectorTags, "node-selector-tags", "q", []string{}, "tag and value seperated by the '=' character (i.e kubernetes.io/os=linux)")
+	exposeCmd.Flags().StringSliceVarP(&DeploymentLabels, "deployment-labels", "l", []string{}, "comma separated list of labels and values seperated by the '=' character (i.e app=application,env=prod)")
 	rootCmd.AddCommand(exposeCmd)
 }

--- a/docs/ktunnel_expose.md
+++ b/docs/ktunnel_expose.md
@@ -31,11 +31,14 @@ ktunnel expose redis 6379
   -c, --ca-file string                TLS cert auth file
       --cert string                   TLS certificate file
       --context string                Kubernetes Context
+  -d, --deployment-only               create only deployment
   -f, --force                         deployment & service will be removed before
   -h, --help                          help for expose
       --key string                    TLS key file
+  -l, --deployment-labels strings     comma separated list of labels and values seperated by the '=' character (i.e name=app,env=prod)
   -n, --namespace string              Namespace (default "default")
   -q, --node-selector-tags strings    tag and value seperated by the '=' character (i.e kubernetes.io/os=linux)
+      --portname string               specify container port name
   -r, --reuse                         delete k8s objects before expose
   -s, --scheme string                 Connection scheme (default "tcp")
   -o, --server-host-override string   Server name use to verify the hostname returned by the TLS handshake

--- a/pkg/k8s/common.go
+++ b/pkg/k8s/common.go
@@ -154,29 +154,24 @@ func newContainer(port int, image string, containerPorts []apiv1.ContainerPort, 
 
 func newDeployment(namespace, name string, port int, image string, ports []apiv1.ContainerPort, selector map[string]string, deploymentLabels map[string]string, cert, key string) *appsv1.Deployment {
 	replicas := int32(1)
-	labels := map[string]string{
-		"app.kubernetes.io/name":     name,
-		"app.kubernetes.io/instance": name,
-	}
-	for key, value := range deploymentLabels {
-		labels[key] = value
-	}
+	deploymentLabels["app.kubernetes.io/name"] = name
+	deploymentLabels["app.kubernetes.io/instance"] = name
 	co := newContainer(port, image, ports, cert, key)
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels:    labels,
+			Labels:    deploymentLabels,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: deploymentLabels,
 			},
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels: deploymentLabels,
 				},
 				Spec: apiv1.PodSpec{
 					NodeSelector: selector,

--- a/pkg/k8s/common.go
+++ b/pkg/k8s/common.go
@@ -152,33 +152,31 @@ func newContainer(port int, image string, containerPorts []apiv1.ContainerPort, 
 	}
 }
 
-func newDeployment(namespace, name string, port int, image string, ports []apiv1.ContainerPort, selector map[string]string, cert, key string) *appsv1.Deployment {
+func newDeployment(namespace, name string, port int, image string, ports []apiv1.ContainerPort, selector map[string]string, deploymentLabels map[string]string, cert, key string) *appsv1.Deployment {
 	replicas := int32(1)
+	labels := map[string]string{
+		"app.kubernetes.io/name":     name,
+		"app.kubernetes.io/instance": name,
+	}
+	for key, value := range deploymentLabels {
+		labels[key] = value
+	}
 	co := newContainer(port, image, ports, cert, key)
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels: map[string]string{
-				"app.kubernetes.io/name":     name,
-				"app.kubernetes.io/instance": name,
-			},
+			Labels:    labels,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"app.kubernetes.io/name":     name,
-					"app.kubernetes.io/instance": name,
-				},
+				MatchLabels: labels,
 			},
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"app.kubernetes.io/name":     name,
-						"app.kubernetes.io/instance": name,
-					},
+					Labels: labels,
 				},
 				Spec: apiv1.PodSpec{
 					NodeSelector: selector,


### PR DESCRIPTION
Idea behind this feature is to add ktunnel deployment into existing service.
Matching selector labels and portname of existing service will add ktunnel deployment into it.