### PR TITLE
Add a flag to set deployment annotations

### DIFF
--- a/docs/ktunnel_expose.md
+++ b/docs/ktunnel_expose.md
@@ -28,22 +28,23 @@ ktunnel expose redis 6379
 ### Options
 
 ```
-  -c, --ca-file string                TLS cert auth file
-      --cert string                   TLS certificate file
-      --context string                Kubernetes Context
-  -d, --deployment-only               create only deployment
-  -f, --force                         deployment & service will be removed before
-  -h, --help                          help for expose
-      --key string                    TLS key file
-  -l, --deployment-labels strings     comma separated list of labels and values seperated by the '=' character (i.e name=app,env=prod)
-  -n, --namespace string              Namespace (default "default")
-  -q, --node-selector-tags strings    tag and value seperated by the '=' character (i.e kubernetes.io/os=linux)
-      --portname string               specify container port name
-  -r, --reuse                         delete k8s objects before expose
-  -s, --scheme string                 Connection scheme (default "tcp")
-  -o, --server-host-override string   Server name use to verify the hostname returned by the TLS handshake
-  -i, --server-image string           Ktunnel server image to use (default "docker.io/omrieival/ktunnel:v1.5.3")
-      --service-type string           exposed service type (ClusterIP, NodePort, LoadBalancer or ExternalName) (default "ClusterIP")
+  -c, --ca-file string                   TLS cert auth file
+      --cert string                      TLS certificate file
+      --context string                   Kubernetes Context
+      --deployment-annotations strings   comma separated list of annotations and values seperated by the '=' character (i.e sidecar.istio.io/inject=false)
+  -l, --deployment-labels strings        comma separated list of labels and values seperated by the '=' character (i.e app=application,env=prod)
+  -d, --deployment-only                  create only deployment
+  -f, --force                            deployment & service will be removed before
+  -h, --help                             help for expose
+      --key string                       TLS key file
+  -n, --namespace string                 Namespace (default "default")
+  -q, --node-selector-tags strings       tag and value seperated by the '=' character (i.e kubernetes.io/os=linux)
+      --portname string                  specify container port name
+  -r, --reuse                            delete k8s objects before expose
+  -s, --scheme string                    Connection scheme (default "tcp")
+  -o, --server-host-override string      Server name use to verify the hostname returned by the TLS handshake
+  -i, --server-image string              Ktunnel server image to use (default "docker.io/omrieival/ktunnel:v1.6.1")
+      --service-type string              exposed service type (ClusterIP, NodePort, LoadBalancer or ExternalName) (default "ClusterIP")
 ```
 
 ### Options inherited from parent commands

--- a/pkg/k8s/common.go
+++ b/pkg/k8s/common.go
@@ -152,7 +152,7 @@ func newContainer(port int, image string, containerPorts []apiv1.ContainerPort, 
 	}
 }
 
-func newDeployment(namespace, name string, port int, image string, ports []apiv1.ContainerPort, selector map[string]string, deploymentLabels map[string]string, cert, key string) *appsv1.Deployment {
+func newDeployment(namespace, name string, port int, image string, ports []apiv1.ContainerPort, selector map[string]string, deploymentLabels map[string]string, deploymentAnnotations map[string]string, cert, key string) *appsv1.Deployment {
 	replicas := int32(1)
 	deploymentLabels["app.kubernetes.io/name"] = name
 	deploymentLabels["app.kubernetes.io/instance"] = name
@@ -160,9 +160,10 @@ func newDeployment(namespace, name string, port int, image string, ports []apiv1
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Labels:    deploymentLabels,
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      deploymentLabels,
+			Annotations: deploymentAnnotations,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
@@ -172,6 +173,7 @@ func newDeployment(namespace, name string, port int, image string, ports []apiv1
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: deploymentLabels,
+					Annotations: deploymentAnnotations,
 				},
 				Spec: apiv1.PodSpec{
 					NodeSelector: selector,


### PR DESCRIPTION
Hello @omrikiei. Thanks for all your work on this project.

I have a Kubernetes application that doesn't support Istio sidecar, but others do. To disable Istio injection for a specific pod, it's necessary to add the annotation `sidecar.istio.io/inject=false`. I wanted to connect the application to a local SigNoz instance to get trace data, but found that `ktunnel` doesn't have a flag to set annotations.

I've prepared a small change to add this capability.