### PR TITLE
Exit with error when portforward fails

### DIFF
--- a/pkg/k8s/common.go
+++ b/pkg/k8s/common.go
@@ -292,7 +292,7 @@ func PortForward(namespace, deploymentName *string, targetPort string, fwdWaitGr
 		}()
 		go func() {
 			if err = forwarder.ForwardPorts(); err != nil { // Locks until stopChan is closed.
-				log.Error(err)
+				log.Fatal(err)
 			}
 		}()
 	}


### PR DESCRIPTION
For example when starting expose with the same port:
ktunnel is stuck: 
ERRO[0005] unable to listen on any of the requested ports: [{28688 28688}]

Instead exit with error 