### PR TITLE
fix: resolve shutdown deadlock on port forwarding when port is already in use

### DIFF
--- a/cmd/expose.go
+++ b/cmd/expose.go
@@ -133,8 +133,6 @@ ktunnel expose redis 6379
 			log.Fatalf("Failed to run port forwarding: %v", err)
 			os.Exit(1)
 		}
-		log.Info("Waiting for port forward to finish")
-		wg.Wait()
 		for _, srcPort := range *sourcePorts {
 			go func(port string) {
 				p, err := strconv.ParseInt(port, 10, 0)

--- a/cmd/inject.go
+++ b/cmd/inject.go
@@ -94,8 +94,6 @@ ktunnel inject deployment mydeployment 3306 6379
 			log.Fatalf("Failed to run port forwarding: %v", err)
 			os.Exit(1)
 		}
-		log.Info("Waiting for port forward to finish")
-		wg.Wait()
 		for _, srcPort := range *sourcePorts {
 			go func(port string) {
 				p, err := strconv.ParseInt(port, 10, 0)

--- a/pkg/k8s/common.go
+++ b/pkg/k8s/common.go
@@ -299,20 +299,20 @@ func PortForward(namespace, deploymentName *string, targetPort string, fwdWaitGr
 		}()
 	}
 
-	waitGroupCh := make(chan struct{})
+	log.Info("Waiting for port forward to finish")
+
+	doneCh := make(chan struct{})
 	go func() {
 		fwdWaitGroup.Wait()
-		close(waitGroupCh)
+		close(doneCh)
 	}()
 
 	select {
 	case err := <-forwarderErrChan:
 		return nil, err
-	case <-waitGroupCh:
-		break
+	case <-doneCh:
+		return &sourcePorts, nil
 	}
-
-	return &sourcePorts, nil
 }
 
 func getPortForwardUrl(config *rest.Config, namespace string, podName string) *url.URL {

--- a/pkg/k8s/common.go
+++ b/pkg/k8s/common.go
@@ -294,7 +294,7 @@ func PortForward(namespace, deploymentName *string, targetPort string, fwdWaitGr
 		}()
 		go func() {
 			if err = forwarder.ForwardPorts(); err != nil { // Locks until stopChan is closed.
-				forwarderErrChan <- fmt.Errorf("unable to forward ports: %w", err)
+				forwarderErrChan <- err
 			}
 		}()
 	}


### PR DESCRIPTION
Concerning https://github.com/omrikiei/ktunnel/issues/129

**Problem**
The `ktunnel expose` command encounters a deadlock, ignoring SIGINTs, and requiring a manual process kill.

**Root Cause**
In the k8s.PortForward function, the fwdWaitGroup counter is not decremented when readyChan is not closed (see [common.go#L281](https://github.com/omrikiei/ktunnel/blob/master/pkg/k8s/common.go#L281)). This results in an unresolved `wg.Wait()` in the expose command (see [expose.go#L137](https://github.com/omrikiei/ktunnel/blob/master/cmd/expose.go#L137)).


**Solution**
To maintain the current function signature of k8s.PortForward, the function should defer its return until all ready signals are received or an error occurs on one of the forwarders.

If changing the function signature is permissible, consider removing fwdWaitGroup as a parameter and creating it within the function itself, as the waiting is already handled internally.

I noticed another open PR (https://github.com/omrikiei/ktunnel/pull/127) that addresses this issue but introduces the side effect of calling os.Exit(1). That could break applications that depend on ktunnel as a module.
