### PR TITLE
fix: set k8s log level to debug when --verbose is set

### DIFF
--- a/cmd/expose.go
+++ b/cmd/expose.go
@@ -48,7 +48,7 @@ ktunnel expose redis 6379
 		ctx, cancel := context.WithCancel(context.Background())
 		if verbose {
 			logger.SetLevel(log.DebugLevel)
-			k8s.Verbose = true
+			k8s.SetLogLevel(log.DebugLevel)
 		}
 		o := sync.Once{}
 

--- a/cmd/inject.go
+++ b/cmd/inject.go
@@ -39,7 +39,7 @@ ktunnel inject deployment mydeployment 3306 6379
 		ctx, cancel := context.WithCancel(context.Background())
 		if verbose {
 			logger.SetLevel(log.DebugLevel)
-			k8s.Verbose = true
+			k8s.SetLogLevel(log.DebugLevel)
 		}
 		o := sync.Once{}
 		// Inject

--- a/pkg/k8s/injector.go
+++ b/pkg/k8s/injector.go
@@ -11,9 +11,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func SetLogLevel(l log.Level) {
+	log.SetLevel(l)
+	if l.String() == "verbose" || l.String() == "debug" {
+		Verbose = true
+	}
+}
+
 func injectToDeployment(o *appsv1.Deployment, c *apiv1.Container, image string, readyChan chan<- bool) (bool, error) {
 	if hasSidecar(o.Spec.Template.Spec, image) {
-		log.Warn(fmt.Sprintf("%s already injected to the deplyoment", image))
+		log.Warn(fmt.Sprintf("%s already injected to the deployment", image))
 		watchForReady(o, readyChan)
 		return true, nil
 	}


### PR DESCRIPTION
This PR makes it so the k8s package log level is set to debug when passing --verbose to the expose or inject commands. I found this helpful for debugging and thought it made sense to contribute back in case it helps someone else!

before:
```
INFO[0002] Exposed service's cluster ip is: xxx
INFO[0002] ProgressDeadlineInSeconds is currently 600s. It may take this long to detect a deployment failure. 
INFO[0002] waiting for deployment to be ready           
INFO[0005] deployment "xxx" successfully rolled out 
INFO[0005] port forwarding to xxx/portforward 
INFO[0005] Waiting for port forward to finish           
INFO[0006] Forwarding from 127.0.0.1:28688 -> 28688
Forwarding from [::1]:28688 -> 28688 
INFO[2024-06-21 16:42:00.608] starting tcp tunnel from source 8443 to target localhost:8443 
DEBU[2024-06-21 16:42:00.700] attempting to receive from stream  
```

after:
```
INFO[0000] Exposed service's cluster ip is: xxx
INFO[0000] ProgressDeadlineInSeconds is currently 600s. It may take this long to detect a deployment failure. 
INFO[0000] waiting for deployment to be ready           
DEBU[0000] Waiting for deployment "xxx" rollout to finish: 0 of 1 updated replicas are available... 
INFO[0001] deployment "xxx" successfully rolled out 
DEBU[0001] Injecting to this pods: [xxx] 
INFO[0001] port forwarding to xxx/portforward 
INFO[0001] Waiting for port forward to finish           
INFO[0001] Forwarding from 127.0.0.1:28688 -> 28688
Forwarding from [::1]:28688 -> 28688 
INFO[2024-06-21 16:44:27.542] starting tcp tunnel from source 8443 to target localhost:8443 
DEBU[2024-06-21 16:44:27.663] attempting to receive from stream 
```