### PR TITLE
fix(client): Fix freeze on closing listener

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 build:
 	@go build
 
+install:
+	@go install
+
 docs: build
 	@GEN_DOC=true ./ktunnel version


### PR DESCRIPTION
When it loses connection to a pod, it freezes until you send the exit signal, I think it'll be better to shut down it if all tunnels are closed

![telegram-cloud-document-2-5285240150043937105](https://github.com/user-attachments/assets/5acaa8f7-aeb1-49ea-9d91-5ec66f218e90)
