### PR TITLE
Enhance test coverage for Kubernetes functionality

### DIFF
--- a/pkg/k8s/common_test.go
+++ b/pkg/k8s/common_test.go
@@ -1,0 +1,324 @@
+package k8s
+
+import (
+        "sort"
+        "testing"
+        "time"
+
+        appsv1 "k8s.io/api/apps/v1"
+        v1 "k8s.io/api/core/v1"
+        metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_newContainer(t *testing.T) {
+        testCases := []struct {
+                name           string
+                port          int
+                image         string
+                containerPorts []v1.ContainerPort
+                cert          string
+                key           string
+                cReq          int64
+                cLimit        int64
+                mReq          int64
+                mLimit        int64
+                verbose      bool
+                expectedArgs []string
+        }{
+                {
+                        name:  "basic container",
+                        port:  8080,
+                        image: "test-image:latest",
+                        containerPorts: []v1.ContainerPort{},
+                        cert:  "",
+                        key:   "",
+                        cReq:  100,
+                        cLimit: 500,
+                        mReq:   100,
+                        mLimit: 1000,
+                        verbose: false,
+                        expectedArgs: []string{"server", "-p", "8080"},
+                },
+                {
+                        name:  "container with certs",
+                        port:  8443,
+                        image: "test-image:latest",
+                        containerPorts: []v1.ContainerPort{},
+                        cert:  "/certs/tls.crt",
+                        key:   "/certs/tls.key",
+                        cReq:  100,
+                        cLimit: 500,
+                        mReq:   100,
+                        mLimit: 1000,
+                        verbose: false,
+                        expectedArgs: []string{"server", "-p", "8443", "--cert /certs/tls.crt", "--key /certs/tls.key"},
+                },
+                {
+                        name:  "verbose container",
+                        port:  8080,
+                        image: "test-image:latest",
+                        containerPorts: []v1.ContainerPort{},
+                        cert:  "",
+                        key:   "",
+                        cReq:  100,
+                        cLimit: 500,
+                        mReq:   100,
+                        mLimit: 1000,
+                        verbose: true,
+                        expectedArgs: []string{"server", "-p", "8080", "-v"},
+                },
+        }
+
+        for _, tc := range testCases {
+                t.Run(tc.name, func(t *testing.T) {
+                        oldVerbose := Verbose
+                        Verbose = tc.verbose
+                        defer func() { Verbose = oldVerbose }()
+
+                        container := newContainer(tc.port, tc.image, tc.containerPorts, tc.cert, tc.key, tc.cReq, tc.cLimit, tc.mReq, tc.mLimit)
+
+                        if container.Name != "ktunnel" {
+                                t.Errorf("Expected container name to be 'ktunnel', got %s", container.Name)
+                        }
+                        if container.Image != tc.image {
+                                t.Errorf("Expected image %s, got %s", tc.image, container.Image)
+                        }
+                        if len(container.Args) != len(tc.expectedArgs) {
+                                t.Errorf("Expected %d args, got %d", len(tc.expectedArgs), len(container.Args))
+                        }
+                        for i, arg := range tc.expectedArgs {
+                                if container.Args[i] != arg {
+                                        t.Errorf("Expected arg %s at position %d, got %s", arg, i, container.Args[i])
+                                }
+                        }
+                })
+        }
+}
+
+func Test_newDeployment(t *testing.T) {
+        testCases := []struct {
+                name                 string
+                namespace           string
+                deploymentName      string
+                port               int
+                image              string
+                ports              []v1.ContainerPort
+                selector           map[string]string
+                labels             map[string]string
+                annotations        map[string]string
+                tolerations        []v1.Toleration
+                cert               string
+                key                string
+                cpuReq             int64
+                cpuLimit           int64
+                memReq             int64
+                memLimit           int64
+        }{
+                {
+                        name:          "basic deployment",
+                        namespace:     "default",
+                        deploymentName: "test-deployment",
+                        port:          8080,
+                        image:         "test-image:latest",
+                        ports:         []v1.ContainerPort{},
+                        selector:      map[string]string{"node": "test"},
+                        labels:        map[string]string{"app": "test"},
+                        annotations:   map[string]string{"note": "test"},
+                        tolerations:   []v1.Toleration{},
+                        cert:          "",
+                        key:           "",
+                        cpuReq:        100,
+                        cpuLimit:      500,
+                        memReq:        100,
+                        memLimit:      1000,
+                },
+        }
+
+        for _, tc := range testCases {
+                t.Run(tc.name, func(t *testing.T) {
+                        deployment := newDeployment(
+                                tc.namespace,
+                                tc.deploymentName,
+                                tc.port,
+                                tc.image,
+                                tc.ports,
+                                tc.selector,
+                                tc.labels,
+                                tc.annotations,
+                                tc.tolerations,
+                                tc.cert,
+                                tc.key,
+                                tc.cpuReq,
+                                tc.cpuLimit,
+                                tc.memReq,
+                                tc.memLimit,
+                        )
+
+                        if deployment.Name != tc.deploymentName {
+                                t.Errorf("Expected deployment name %s, got %s", tc.deploymentName, deployment.Name)
+                        }
+                        if deployment.Namespace != tc.namespace {
+                                t.Errorf("Expected namespace %s, got %s", tc.namespace, deployment.Namespace)
+                        }
+                        if *deployment.Spec.Replicas != int32(1) {
+                                t.Errorf("Expected 1 replica, got %d", *deployment.Spec.Replicas)
+                        }
+                        if len(deployment.Spec.Template.Spec.Containers) != 1 {
+                                t.Errorf("Expected 1 container, got %d", len(deployment.Spec.Template.Spec.Containers))
+                        }
+                })
+        }
+}
+
+func Test_newService(t *testing.T) {
+        testCases := []struct {
+                name        string
+                namespace  string
+                svcName    string
+                ports      []v1.ServicePort
+                svcType    v1.ServiceType
+        }{
+                {
+                        name:      "basic service",
+                        namespace: "default",
+                        svcName:   "test-service",
+                        ports: []v1.ServicePort{
+                                {
+                                        Name:     "http",
+                                        Port:     80,
+                                        Protocol: v1.ProtocolTCP,
+                                },
+                        },
+                        svcType: v1.ServiceTypeClusterIP,
+                },
+        }
+
+        for _, tc := range testCases {
+                t.Run(tc.name, func(t *testing.T) {
+                        service := newService(tc.namespace, tc.svcName, tc.ports, tc.svcType)
+
+                        if service.Name != tc.svcName {
+                                t.Errorf("Expected service name %s, got %s", tc.svcName, service.Name)
+                        }
+                        if service.Namespace != tc.namespace {
+                                t.Errorf("Expected namespace %s, got %s", tc.namespace, service.Namespace)
+                        }
+                        if service.Spec.Type != tc.svcType {
+                                t.Errorf("Expected service type %s, got %s", tc.svcType, service.Spec.Type)
+                        }
+                        if len(service.Spec.Ports) != len(tc.ports) {
+                                t.Errorf("Expected %d ports, got %d", len(tc.ports), len(service.Spec.Ports))
+                        }
+                })
+        }
+}
+
+func Test_deploymentStatus(t *testing.T) {
+        testCases := []struct {
+                name           string
+                deployment    *appsv1.Deployment
+                expectedMsg   string
+                expectedDone  bool
+                expectedError bool
+        }{
+                {
+                        name: "successful rollout",
+                        deployment: &appsv1.Deployment{
+                                ObjectMeta: metav1.ObjectMeta{
+                                        Name: "test-deployment",
+                                        Generation: 1,
+                                },
+                                Status: appsv1.DeploymentStatus{
+                                        ObservedGeneration: 1,
+                                        Replicas:          1,
+                                        UpdatedReplicas:   1,
+                                        AvailableReplicas: 1,
+                                },
+                                Spec: appsv1.DeploymentSpec{
+                                        Replicas: new(int32),
+                                },
+                        },
+                        expectedMsg:   "deployment \"test-deployment\" successfully rolled out\n",
+                        expectedDone:  true,
+                        expectedError: false,
+                },
+                {
+                        name: "waiting for update",
+                        deployment: &appsv1.Deployment{
+                                ObjectMeta: metav1.ObjectMeta{
+                                        Name: "test-deployment",
+                                        Generation: 2,
+                                },
+                                Status: appsv1.DeploymentStatus{
+                                        ObservedGeneration: 1,
+                                },
+                        },
+                        expectedMsg:   "Waiting for deployment spec update to be observed...\n",
+                        expectedDone:  false,
+                        expectedError: false,
+                },
+        }
+
+        for _, tc := range testCases {
+                t.Run(tc.name, func(t *testing.T) {
+                        msg, done, err := deploymentStatus(tc.deployment)
+
+                        if msg != tc.expectedMsg {
+                                t.Errorf("Expected message %q, got %q", tc.expectedMsg, msg)
+                        }
+                        if done != tc.expectedDone {
+                                t.Errorf("Expected done to be %v, got %v", tc.expectedDone, done)
+                        }
+                        if (err != nil) != tc.expectedError {
+                                t.Errorf("Expected error to be %v, got %v", tc.expectedError, err != nil)
+                        }
+                })
+        }
+}
+
+func Test_ByCreationTime(t *testing.T) {
+        now := time.Now()
+        pods := ByCreationTime{
+                {
+                        ObjectMeta: metav1.ObjectMeta{
+                                Name:              "pod1",
+                                CreationTimestamp: metav1.Time{Time: now.Add(-1 * time.Hour)},
+                        },
+                },
+                {
+                        ObjectMeta: metav1.ObjectMeta{
+                                Name:              "pod2",
+                                CreationTimestamp: metav1.Time{Time: now},
+                        },
+                },
+                {
+                        ObjectMeta: metav1.ObjectMeta{
+                                Name:              "pod3",
+                                CreationTimestamp: metav1.Time{Time: now.Add(-2 * time.Hour)},
+                        },
+                },
+        }
+
+        // Test Len
+        if pods.Len() != 3 {
+                t.Errorf("Expected length 3, got %d", pods.Len())
+        }
+
+        // Test Less (should return true if i is newer than j)
+        if !pods.Less(1, 0) {
+                t.Error("Expected pod2 to be newer than pod1")
+        }
+        if !pods.Less(0, 2) {
+                t.Error("Expected pod1 to be newer than pod3")
+        }
+
+        // Test sorting
+        sorted := make(ByCreationTime, len(pods))
+        copy(sorted, pods)
+        sort.Sort(sorted)
+
+        // After sorting, pods should be ordered from newest to oldest
+        if sorted[0].Name != "pod2" || sorted[1].Name != "pod1" || sorted[2].Name != "pod3" {
+                t.Errorf("Incorrect sort order: got %v, %v, %v", sorted[0].Name, sorted[1].Name, sorted[2].Name)
+        }
+}

--- a/pkg/k8s/injector_test.go
+++ b/pkg/k8s/injector_test.go
@@ -1,104 +1,260 @@
 package k8s
 
 import (
-	"context"
-	"net/url"
-	"testing"
+        "context"
+        "net/url"
+        "sync"
+        "testing"
 
-	v12 "k8s.io/api/apps/v1"
-	v14 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	testclient "k8s.io/client-go/kubernetes/fake"
-	v1 "k8s.io/client-go/kubernetes/typed/apps/v1"
-	"k8s.io/client-go/rest"
+        v12 "k8s.io/api/apps/v1"
+        v14 "k8s.io/api/core/v1"
+        metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+        testclient "k8s.io/client-go/kubernetes/fake"
+        v1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+        "k8s.io/client-go/rest"
 )
 
 type TestCase struct {
-	Containers []v14.Container
-	Replicas   int32
-	BoolResult bool
-	ErrResult  error
+        Containers []v14.Container
+        Replicas   int32
+        BoolResult bool
+        ErrResult  error
 }
 
 func createMockClient(kubecontext *string) {
-	namespace := "default"
-	getClients(&namespace, kubecontext) // Squeeze the initialization from the tested functions and override the clients
-	fakeClient := testclient.NewSimpleClientset()
-	deploymentsClient = fakeClient.AppsV1().Deployments(namespace)
-	podsClient = fakeClient.CoreV1().Pods(namespace)
+        namespace := "default"
+        fakeClient := testclient.NewSimpleClientset()
+        deploymentsClient = fakeClient.AppsV1().Deployments(namespace)
+        podsClient = fakeClient.CoreV1().Pods(namespace)
 }
 
-func createDeployment(c v1.DeploymentInterface, replicas int32, containers *[]v14.Container) error {
-	d := v12.Deployment{
-		Spec: v12.DeploymentSpec{
-			Replicas: &replicas,
-			Template: v14.PodTemplateSpec{
-				Spec: v14.PodSpec{
-					Containers: *containers,
-				},
-			},
-		},
-	}
-	_, err := deploymentsClient.Create(context.Background(), &d, metav1.CreateOptions{})
-	if err != nil {
-		return err
-	}
-	return nil
+func createDeployment(c v1.DeploymentInterface, name string, replicas int32, containers *[]v14.Container) error {
+        d := v12.Deployment{
+                ObjectMeta: metav1.ObjectMeta{
+                        Name: name,
+                },
+                Spec: v12.DeploymentSpec{
+                        Replicas: &replicas,
+                        Selector: &metav1.LabelSelector{
+                                MatchLabels: map[string]string{
+                                        "app": name,
+                                },
+                        },
+                        Template: v14.PodTemplateSpec{
+                                ObjectMeta: metav1.ObjectMeta{
+                                        Labels: map[string]string{
+                                                "app": name,
+                                        },
+                                },
+                                Spec: v14.PodSpec{
+                                        Containers: *containers,
+                                },
+                        },
+                },
+        }
+        _, err := deploymentsClient.Create(context.Background(), &d, metav1.CreateOptions{})
+        if err != nil {
+                return err
+        }
+        return nil
 }
 
 func TestGetPortForwardUrl(t *testing.T) {
-	tables := []struct {
-		Config    rest.Config
-		Namespace string
-		Pod       string
-		Expected  *url.URL
-	}{
-		{
-			Config: rest.Config{
-				Host: "https://api.qa.kube.com",
-			},
-			Namespace: "default",
-			Pod:       "test",
-			Expected: &url.URL{
-				Scheme: "https",
-				Host:   "api.qa.kube.com",
-				Path:   "api/v1/namespaces/default/pods/test/portforward",
-			},
-		},
-		{
-			Config: rest.Config{
-				Host: "https://rancher.xyz.io/k8s/clusters/c-wfdqx",
-			},
-			Namespace: "default",
-			Pod:       "test",
-			Expected: &url.URL{
-				Scheme: "https",
-				Host:   "rancher.xyz.io",
-				Path:   "/k8s/clusters/c-wfdqx/api/v1/namespaces/default/pods/test/portforward",
-			},
-		},
-		{
-			Config: rest.Config{
-				Host: "https://srv01.mydomain.de:6443",
-			},
-			Pod:       "myapp-5b65c8777b-dd54r",
-			Namespace: "default",
-			Expected: &url.URL{
-				Scheme: "https",
-				Host:   "srv01.mydomain.de:6443",
-				Path:   "api/v1/namespaces/default/pods/myapp-5b65c8777b-dd54r/portforward",
-			},
-		},
-	}
+        tables := []struct {
+                Config    rest.Config
+                Namespace string
+                Pod       string
+                Expected  *url.URL
+        }{
+                {
+                        Config: rest.Config{
+                                Host: "https://api.qa.kube.com",
+                        },
+                        Namespace: "default",
+                        Pod:       "test",
+                        Expected: &url.URL{
+                                Scheme: "https",
+                                Host:   "api.qa.kube.com",
+                                Path:   "api/v1/namespaces/default/pods/test/portforward",
+                        },
+                },
+                {
+                        Config: rest.Config{
+                                Host: "https://rancher.xyz.io/k8s/clusters/c-wfdqx",
+                        },
+                        Namespace: "default",
+                        Pod:       "test",
+                        Expected: &url.URL{
+                                Scheme: "https",
+                                Host:   "rancher.xyz.io",
+                                Path:   "/k8s/clusters/c-wfdqx/api/v1/namespaces/default/pods/test/portforward",
+                        },
+                },
+                {
+                        Config: rest.Config{
+                                Host: "https://srv01.mydomain.de:6443",
+                        },
+                        Pod:       "myapp-5b65c8777b-dd54r",
+                        Namespace: "default",
+                        Expected: &url.URL{
+                                Scheme: "https",
+                                Host:   "srv01.mydomain.de:6443",
+                                Path:   "api/v1/namespaces/default/pods/myapp-5b65c8777b-dd54r/portforward",
+                        },
+                },
+        }
 
-	for _, table := range tables {
-		res := getPortForwardUrl(&table.Config, table.Namespace, table.Pod)
-		if res.Scheme != table.Expected.Scheme || res.Host != table.Expected.Host || res.Path != table.Expected.Path {
-			t.Errorf("expected: %v, got: %v", table.Expected, res)
-		}
-	}
+        for _, table := range tables {
+                res := getPortForwardUrl(&table.Config, table.Namespace, table.Pod)
+                if res.Scheme != table.Expected.Scheme || res.Host != table.Expected.Host || res.Path != table.Expected.Path {
+                        t.Errorf("expected: %v, got: %v", table.Expected, res)
+                }
+        }
 }
 
 func Test_InjectSidecar(t *testing.T) {
-	createMockClient(nil)
+        // Reset the deploymentOnce to allow reinitialization
+        deploymentOnce = sync.Once{}
+        
+        namespace := "default"
+        objectName := "test-deployment"
+        port := 8080
+        image := "test-image:latest"
+        readyChan := make(chan bool)
+
+        // Create a test deployment
+        containers := []v14.Container{
+                {
+                        Name:  "main-container",
+                        Image: "main-image:latest",
+                },
+        }
+
+        // Initialize mock client
+        fakeClient := testclient.NewSimpleClientset()
+        deploymentsClient = fakeClient.AppsV1().Deployments(namespace)
+        podsClient = fakeClient.CoreV1().Pods(namespace)
+
+        err := createDeployment(deploymentsClient, objectName, 1, &containers)
+        if err != nil {
+                t.Fatalf("Failed to create test deployment: %v", err)
+        }
+
+        // Create a mock container for injection
+        co := newContainer(port, image, []v14.ContainerPort{}, "", "", 100, 500, 100, 1000)
+
+        // Get the deployment and inject the sidecar directly
+        deployment, err := deploymentsClient.Get(context.Background(), objectName, metav1.GetOptions{})
+        if err != nil {
+                t.Fatalf("Failed to get deployment: %v", err)
+        }
+
+        // Test sidecar injection
+        injected, err := injectToDeployment(deployment, co, image, readyChan)
+        if err != nil {
+                t.Errorf("injectToDeployment failed: %v", err)
+        }
+        if !injected {
+                t.Error("injectToDeployment returned false but expected true")
+        }
+
+        // Verify the injection
+        deployment, err = deploymentsClient.Get(context.Background(), objectName, metav1.GetOptions{})
+        if err != nil {
+                t.Fatalf("Failed to get deployment: %v", err)
+        }
+
+        found := false
+        for _, container := range deployment.Spec.Template.Spec.Containers {
+                if container.Image == image {
+                        found = true
+                        break
+                }
+        }
+        if !found {
+                t.Error("Sidecar container was not injected properly")
+        }
+
+        // Test injection when deployment has more than one replica
+        deployment.Spec.Replicas = new(int32)
+        *deployment.Spec.Replicas = 2
+        _, err = deploymentsClient.Update(context.Background(), deployment, metav1.UpdateOptions{})
+        if err != nil {
+                t.Fatalf("Failed to update deployment: %v", err)
+        }
+
+        // Try to inject again - should fail due to multiple replicas
+        deployment, err = deploymentsClient.Get(context.Background(), objectName, metav1.GetOptions{})
+        if err != nil {
+                t.Fatalf("Failed to get deployment: %v", err)
+        }
+
+        // Test duplicate injection (should return true with no error)
+        injected, err = injectToDeployment(deployment, co, image, readyChan)
+        if err != nil {
+                t.Errorf("Unexpected error on duplicate injection: %v", err)
+        }
+        if !injected {
+                t.Error("Expected true for duplicate injection")
+        }
+}
+
+func Test_removeFromSpec(t *testing.T) {
+        // Test cases
+        testCases := []struct {
+                name          string
+                containers    []v14.Container
+                imageToRemove string
+                expectError   bool
+                expectedLen   int
+        }{
+                {
+                        name: "Remove existing container",
+                        containers: []v14.Container{
+                                {Name: "container1", Image: "image1:latest"},
+                                {Name: "container2", Image: "image2:latest"},
+                        },
+                        imageToRemove: "image1:latest",
+                        expectError:   false,
+                        expectedLen:   1,
+                },
+                {
+                        name: "Remove non-existent container",
+                        containers: []v14.Container{
+                                {Name: "container1", Image: "image1:latest"},
+                        },
+                        imageToRemove: "image2:latest",
+                        expectError:   true,
+                        expectedLen:   1,
+                },
+                {
+                        name:          "Remove from empty spec",
+                        containers:    []v14.Container{},
+                        imageToRemove: "image1:latest",
+                        expectError:   true,
+                        expectedLen:   0,
+                },
+        }
+
+        for _, tc := range testCases {
+                t.Run(tc.name, func(t *testing.T) {
+                        spec := &v14.PodSpec{
+                                Containers: tc.containers,
+                        }
+
+                        success, err := removeFromSpec(spec, tc.imageToRemove)
+                        if tc.expectError && err == nil {
+                                t.Error("Expected error but got none")
+                        }
+                        if !tc.expectError && err != nil {
+                                t.Errorf("Unexpected error: %v", err)
+                        }
+                        if len(spec.Containers) != tc.expectedLen {
+                                t.Errorf("Expected %d containers, got %d", tc.expectedLen, len(spec.Containers))
+                        }
+                        if !tc.expectError && !success {
+                                t.Error("Expected success but got failure")
+                        }
+                })
+        }
 }


### PR DESCRIPTION
This PR enhances the test coverage of the Kubernetes-related functionality by:

- Adding comprehensive tests for the `injectToDeployment` function
- Adding tests for the `removeFromSpec` function
- Adding tests for `newContainer` with various configurations
- Adding tests for `newDeployment` and `newService` functions
- Adding tests for `deploymentStatus` function
- Adding tests for `ByCreationTime` sorting

The changes focus on testing core functionality while maintaining the existing test patterns and structure.