### PR TITLE
Watch the created deployment, not the local template

### DIFF
--- a/pkg/k8s/exposer.go
+++ b/pkg/k8s/exposer.go
@@ -80,7 +80,7 @@ func (k *KubeService) ExposeAsService(
 		}
 	}
 
-	deployment := newDeployment(
+	deploymentTemplate := newDeployment(
 		namespace,
 		name,
 		tunnelPort,
@@ -100,12 +100,12 @@ func (k *KubeService) ExposeAsService(
 
 	service := newService(namespace, name, ports, v12.ServiceType(serviceType))
 
-	var d *appsv1.Deployment
+	var deployment *appsv1.Deployment
 	var err error
 	deploymentCreated := false
 	existingDeployment, err := deploymentsClient.Get(context.Background(), name, v1.GetOptions{})
 	if err != nil && apierrors.IsNotFound(err) {
-		d, err = deploymentsClient.Create(context.Background(), deployment, v1.CreateOptions{
+		deployment, err = deploymentsClient.Create(context.Background(), deploymentTemplate, v1.CreateOptions{
 			TypeMeta:     v1.TypeMeta{},
 			DryRun:       nil,
 			FieldManager: "",
@@ -119,16 +119,16 @@ func (k *KubeService) ExposeAsService(
 	}
 	if !deploymentCreated && Reuse {
 		// Copy annotations, labels and selectors to prevent PATCH issue with immutable fields
-		deployment.Annotations = existingDeployment.Annotations
-		deployment.Labels = existingDeployment.Labels
-		deployment.Spec.Selector = existingDeployment.Spec.Selector
-		deployment.Spec.Template.Labels = existingDeployment.Spec.Template.Labels
+		deploymentTemplate.Annotations = existingDeployment.Annotations
+		deploymentTemplate.Labels = existingDeployment.Labels
+		deploymentTemplate.Spec.Selector = existingDeployment.Spec.Selector
+		deploymentTemplate.Spec.Template.Labels = existingDeployment.Spec.Template.Labels
 
-		patch, err := json.Marshal(deployment)
+		patch, err := json.Marshal(deploymentTemplate)
 		if err != nil {
 			return err
 		}
-		d, err = deploymentsClient.Patch(context.Background(), name, types.MergePatchType, patch, v1.PatchOptions{
+		deployment, err = deploymentsClient.Patch(context.Background(), name, types.MergePatchType, patch, v1.PatchOptions{
 			TypeMeta:     v1.TypeMeta{},
 			DryRun:       nil,
 			FieldManager: "",
@@ -139,7 +139,7 @@ func (k *KubeService) ExposeAsService(
 		}
 	}
 
-	if d == nil {
+	if deployment == nil {
 		if !deploymentCreated {
 			return errors.New("deployment with same name already exists")
 		}


### PR DESCRIPTION
The second of the two fixes in #147. The first — polling instead of
watching — landed in #154.

`ExposeAsService` built a Deployment spec, sent it to the API server,
and then passed the **local** spec to `watchForReady`, while the object
the server actually returned sat unused in `d`.

The returned object is the one with a populated spec. Reading readiness
settings off the local template means:

- `Spec.ProgressDeadlineSeconds` is always nil, so the deadline silently
  falls back to the 600s default rather than the deployment's real value
- `Spec.Strategy` is zero, so the `RollingUpdate.MaxUnavailable` warning
  can never fire — the warning exists precisely to tell you when
  deployment failures may go undetected

Renaming the local spec to `deploymentTemplate` and giving the
server-returned object the `deployment` name makes the variable that
reaches `watchForReady` the one that has been through the API server.
No behaviour depends on the old names.

Credit to @doctorpangloss (#147), which cannot be merged as-is because
it also rebrands the project to a fork, redirects `FUNDING.yml`, and
deletes the Homebrew tap config — but both of its fixes are real.

`go test -race`, `go vet` and `gofmt` clean.