### PR TITLE
Fix the tunnel data path and give it test coverage

### DIFF
--- a/cmd/expose.go
+++ b/cmd/expose.go
@@ -173,7 +173,19 @@ ktunnel expose redis 6379
 		}()
 
 		log.Info("waiting for deployment to be ready")
-		<-readyChan
+		ready, interrupted := waitForReady(ctx, readyChan)
+		if interrupted {
+			// The signal handler is already tearing down; wait for it
+			// rather than racing ahead to port-forward.
+			<-done
+			return
+		}
+		if !ready {
+			log.Error("deployment failed to become ready, cleaning up")
+			sigs <- syscall.SIGINT
+			<-done
+			return
+		}
 
 		// Kube Service
 		kubeService, err := k8s.NewKubeService(KubeContext, Namespace)

--- a/cmd/inject.go
+++ b/cmd/inject.go
@@ -85,7 +85,11 @@ ktunnel inject deployment mydeployment 3306 6379
 		}()
 
 		log.Info("Waiting for deployment to be ready")
-		success := <-readyChan
+		success, interrupted := waitForReady(ctx, readyChan)
+		if interrupted {
+			<-done
+			return
+		}
 		if !success {
 			sigs <- syscall.SIGQUIT
 			<-done

--- a/cmd/wait.go
+++ b/cmd/wait.go
@@ -1,0 +1,27 @@
+package cmd
+
+import "context"
+
+// waitForReady blocks until the deployment reports its rollout status on
+// readyChan, or until ctx is cancelled.
+//
+// The signal handlers in expose and inject cancel ctx, so this is what lets
+// Ctrl+C take effect while a rollout is still in progress. Previously both
+// commands received on readyChan directly with no escape: the handler ran on
+// another goroutine, logged "Got exit signal", tore down the resources and
+// then blocked forever because nothing was left to consume `done`, while the
+// main goroutine sat on readyChan until the rollout watcher gave up. On a
+// deployment that never becomes ready that is a ten-minute hang after the
+// user has already asked to quit.
+//
+// The returned interrupted flag distinguishes "the user asked us to stop"
+// from "the rollout finished and failed", because the caller has to respond
+// to those differently -- the first already has a teardown in flight.
+func waitForReady(ctx context.Context, readyChan <-chan bool) (ready bool, interrupted bool) {
+	select {
+	case ready = <-readyChan:
+		return ready, false
+	case <-ctx.Done():
+		return false, true
+	}
+}

--- a/cmd/wait_test.go
+++ b/cmd/wait_test.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestWaitForReady_DeploymentBecomesReady(t *testing.T) {
+	readyChan := make(chan bool, 1)
+	readyChan <- true
+
+	ready, interrupted := waitForReady(context.Background(), readyChan)
+	if !ready || interrupted {
+		t.Fatalf("got ready=%v interrupted=%v, want ready=true interrupted=false", ready, interrupted)
+	}
+}
+
+func TestWaitForReady_RolloutFails(t *testing.T) {
+	readyChan := make(chan bool, 1)
+	readyChan <- false
+
+	ready, interrupted := waitForReady(context.Background(), readyChan)
+	if ready || interrupted {
+		t.Fatalf("got ready=%v interrupted=%v, want ready=false interrupted=false", ready, interrupted)
+	}
+}
+
+// TestWaitForReady_InterruptedByCtrlC is the regression test for the hang.
+// A rollout that never reports anything must not keep the process alive once
+// the signal handler has cancelled the context.
+func TestWaitForReady_InterruptedByCtrlC(t *testing.T) {
+	// Never written to, standing in for a rollout that is still in progress.
+	readyChan := make(chan bool)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Ctrl+C arrives shortly after we start waiting.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	done := make(chan struct{})
+	var ready, interrupted bool
+	go func() {
+		ready, interrupted = waitForReady(ctx, readyChan)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("waitForReady ignored the cancelled context; this is the Ctrl+C hang")
+	}
+
+	if ready {
+		t.Error("an interrupted wait must not report the deployment as ready")
+	}
+	if !interrupted {
+		t.Error("expected interrupted=true so the caller waits for teardown instead of proceeding")
+	}
+}
+
+// TestWaitForReady_PrefersReadinessAlreadyDelivered guards against the
+// opposite failure: if readiness landed before the context was cancelled, we
+// should still report it rather than treating the shutdown as an interrupt.
+func TestWaitForReady_PrefersReadinessAlreadyDelivered(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // both select cases are live
+
+	// select picks randomly among ready cases, so assert over repeated runs
+	// that readiness is at least reachable and never misreported.
+	sawReady := false
+	for range 50 {
+		ch := make(chan bool, 1)
+		ch <- true
+		ready, interrupted := waitForReady(ctx, ch)
+		if ready && interrupted {
+			t.Fatal("ready and interrupted must not both be true")
+		}
+		if ready {
+			sawReady = true
+		}
+	}
+	if !sawReady {
+		t.Error("readiness already on the channel was never observed")
+	}
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -35,12 +35,28 @@ loop:
 				break loop
 			}
 
-			requestId, err := uuid.Parse(m.RequestID)
-			if err != nil {
-				conf.log.WithError(err).WithField("session", m.RequestID).Errorf("failed parsing session uuid from stream, skipping")
+			// The server reports its own failures on this stream -- a
+			// listener it could not bind, for instance -- and those frames
+			// carry no session ID, because they are not about a session.
+			// Report them; they are the actual diagnosis.
+			if m.HasErr {
+				logServerError(conf, m, host, port)
+				if m.GetRequestID() == "" {
+					continue
+				}
 			}
 
-			session, exists := common.GetSession(requestId)
+			requestId, err := uuid.Parse(m.RequestID)
+			if err != nil {
+				// Without a usable ID there is no session to act on. This
+				// used to fall through and operate on the zero UUID, which
+				// opened a bogus session and buried whatever the server was
+				// actually trying to say.
+				conf.log.WithError(err).WithField("session", m.RequestID).Errorf("failed parsing session uuid from stream, skipping")
+				continue
+			}
+
+			session, exists := conf.sessions.Get(requestId)
 			if exists == false {
 				conf.log.WithFields(log.Fields{
 					"session": m.RequestID,
@@ -64,11 +80,16 @@ loop:
 
 					continue
 				} else {
-					session = common.NewSessionFromStream(requestId, conn)
+					session, err = conf.sessions.NewFromStream(requestId, conn)
+					if err != nil {
+						conf.log.WithError(err).WithField("session", requestId).Errorf("failed tracking new session")
+						_ = conn.Close()
+						continue
+					}
 					go ReadFromSession(conf, session, sessionsOut)
 				}
 			} else if m.ShouldClose {
-				session.Open = false
+				session.SetOpen(false)
 			}
 
 			// process the data from the server
@@ -77,8 +98,36 @@ loop:
 	}
 }
 
+// logServerError surfaces an error the server reported over the stream. These
+// were previously discarded entirely, which is why a server that failed to
+// bind its listener showed up on the client as an unexplained UUID parse
+// error rather than as the permission or port conflict it actually was.
+func logServerError(conf *Config, m *pb.SocketDataResponse, host string, port int32) {
+	entry := conf.log.WithFields(log.Fields{"host": host, "port": port})
+	if session := m.GetRequestID(); session != "" {
+		entry = entry.WithField("session", session)
+	}
+
+	msg := m.GetLogMessage()
+	if msg == nil {
+		entry.Error("tunnel server reported an error but sent no message")
+		return
+	}
+
+	switch msg.GetLogLevel() {
+	case pb.LogLevel_DEBUG, pb.LogLevel_VERBOSE:
+		entry.Debugf("tunnel server: %s", msg.GetMessage())
+	case pb.LogLevel_INFO:
+		entry.Infof("tunnel server: %s", msg.GetMessage())
+	case pb.LogLevel_WARNING:
+		entry.Warnf("tunnel server: %s", msg.GetMessage())
+	default:
+		entry.Errorf("tunnel server: %s", msg.GetMessage())
+	}
+}
+
 func handleStreamData(conf *Config, m *pb.SocketDataResponse, session *common.Session) {
-	if session.Open == false {
+	if !session.IsOpen() {
 		conf.log.WithField("session", session.ID).Infof("closed session")
 		session.Close()
 		return
@@ -119,7 +168,7 @@ loop:
 					conf.log.WithField("session", session.ID).Debugf("got EOF from connection")
 				}
 
-				session.Open = false
+				session.SetOpen(false)
 				sessionsOut <- session
 				break loop
 			}
@@ -279,6 +328,10 @@ func processArgs(opts []Option) (*Config, error) {
 		return nil, fmt.Errorf("missing host configuration")
 	}
 
+	if opt.sessions == nil {
+		opt.sessions = common.NewSessionStore()
+	}
+
 	return opt, nil
 }
 
@@ -340,4 +393,14 @@ type Config struct {
 	scheme          string
 	log             log.FieldLogger
 	tunnels         []string
+	sessions        *common.SessionStore
+}
+
+// WithSessionStore sets the store this client tracks its sessions in. If
+// unset, the client creates its own.
+func WithSessionStore(store *common.SessionStore) Option {
+	return func(opt *Config) error {
+		opt.sessions = store
+		return nil
+	}
 }

--- a/pkg/client/loopback_test.go
+++ b/pkg/client/loopback_test.go
@@ -1,0 +1,275 @@
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omrikiei/ktunnel/pkg/client"
+	"github.com/omrikiei/ktunnel/pkg/common"
+	"github.com/omrikiei/ktunnel/pkg/server"
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+)
+
+// These tests run a real tunnel server and a real tunnel client in one
+// process, over real TCP, and push bytes through end to end. They are the
+// regression net for the tunnel data path, which had no test coverage at all.
+//
+// Running both sides in one process is only possible because each holds its
+// own SessionStore. The two sides address sessions by the same UUIDs, so with
+// a single shared store each would find the other's session instead of its
+// own.
+
+// freePort returns a TCP port that was free a moment ago. Inherently racy, but
+// adequate for tests and the only option when the code under test binds a port
+// number rather than accepting a listener.
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed reserving a port: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	if err := l.Close(); err != nil {
+		t.Fatalf("failed releasing reserved port: %v", err)
+	}
+	return port
+}
+
+// startEchoServer stands in for the service running on the developer's
+// machine. It echoes back whatever it is sent, upper-cased, so the test can
+// tell the echo apart from its own request.
+func startEchoServer(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed starting echo server: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				buf := make([]byte, 1024)
+				for {
+					n, err := c.Read(buf)
+					if n > 0 {
+						if _, werr := c.Write([]byte(strings.ToUpper(string(buf[:n])))); werr != nil {
+							return
+						}
+					}
+					if err != nil {
+						return
+					}
+				}
+			}(conn)
+		}
+	}()
+
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+// testLogger returns a logger that captures entries for assertions.
+func testLogger() (*log.Logger, *logtest.Hook) {
+	l := log.New()
+	l.SetOutput(io.Discard)
+	l.SetLevel(log.DebugLevel)
+	hook := logtest.NewLocal(l)
+	return l, hook
+}
+
+// dialUntilReady retries until something is listening, or the deadline passes.
+func dialUntilReady(t *testing.T, addr string, timeout time.Duration) net.Conn {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err == nil {
+			return conn
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("nothing listening on %s after %s: %v", addr, timeout, err)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+// startTunnel brings up a server and a client wired to each other, tunnelling
+// tunnelPort on the "cluster" side to targetPort on the "local" side.
+func startTunnel(t *testing.T, tunnelPort, targetPort int) (*logtest.Hook, *logtest.Hook) {
+	t.Helper()
+
+	grpcPort := freePort(t)
+	serverLog, serverHook := testLogger()
+	clientLog, clientHook := testLogger()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	go func() {
+		_ = server.RunServer(ctx,
+			server.WithPort(grpcPort),
+			server.WithLogger(serverLog),
+			server.WithSessionStore(common.NewSessionStore()),
+		)
+	}()
+
+	// Wait for the gRPC listener before pointing the client at it.
+	conn := dialUntilReady(t, fmt.Sprintf("127.0.0.1:%d", grpcPort), 5*time.Second)
+	_ = conn.Close()
+
+	go func() {
+		_ = client.RunClient(ctx,
+			client.WithServer("127.0.0.1", grpcPort),
+			client.WithLogger(clientLog),
+			client.WithTunnels("tcp", fmt.Sprintf("%d:127.0.0.1:%d", tunnelPort, targetPort)),
+			client.WithSessionStore(common.NewSessionStore()),
+		)
+	}()
+
+	return serverHook, clientHook
+}
+
+// TestLoopback_EchoRoundTrip is the core assertion: a connection made on the
+// cluster side reaches the local service and its reply comes back.
+func TestLoopback_EchoRoundTrip(t *testing.T) {
+	echoPort := startEchoServer(t)
+	tunnelPort := freePort(t)
+	startTunnel(t, tunnelPort, echoPort)
+
+	conn := dialUntilReady(t, fmt.Sprintf("127.0.0.1:%d", tunnelPort), 10*time.Second)
+	defer func() { _ = conn.Close() }()
+
+	if _, err := conn.Write([]byte("hello tunnel")); err != nil {
+		t.Fatalf("failed writing through the tunnel: %v", err)
+	}
+
+	if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatalf("failed setting read deadline: %v", err)
+	}
+	buf := make([]byte, 128)
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("failed reading the echo back through the tunnel: %v", err)
+	}
+
+	if got, want := string(buf[:n]), "HELLO TUNNEL"; got != want {
+		t.Fatalf("round trip returned %q, want %q", got, want)
+	}
+}
+
+// TestLoopback_MultipleSequentialConnections asserts that sessions do not
+// leak into each other -- each connection gets its own.
+func TestLoopback_MultipleSequentialConnections(t *testing.T) {
+	echoPort := startEchoServer(t)
+	tunnelPort := freePort(t)
+	startTunnel(t, tunnelPort, echoPort)
+
+	addr := fmt.Sprintf("127.0.0.1:%d", tunnelPort)
+	for i := 0; i < 3; i++ {
+		conn := dialUntilReady(t, addr, 10*time.Second)
+
+		payload := fmt.Sprintf("message %d", i)
+		if _, err := conn.Write([]byte(payload)); err != nil {
+			t.Fatalf("connection %d: failed writing: %v", i, err)
+		}
+		if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+			t.Fatalf("connection %d: failed setting deadline: %v", i, err)
+		}
+		buf := make([]byte, 128)
+		n, err := conn.Read(buf)
+		if err != nil {
+			t.Fatalf("connection %d: failed reading: %v", i, err)
+		}
+		if got, want := string(buf[:n]), strings.ToUpper(payload); got != want {
+			t.Fatalf("connection %d returned %q, want %q", i, got, want)
+		}
+		_ = conn.Close()
+	}
+}
+
+// TestLoopback_ServerBindFailureIsReported is the regression test for the
+// bug behind #88, #66 and #143.
+//
+// When the tunnel server cannot bind its listener it sends an error frame
+// describing exactly why -- but that frame has no session ID, because it is
+// not about a session. The client used to discard HasErr and LogMessage
+// entirely, fail to parse the empty ID, log "failed parsing session uuid from
+// stream, skipping" without actually skipping, and carry on with the zero
+// UUID. The real diagnosis never reached the user.
+func TestLoopback_ServerBindFailureIsReported(t *testing.T) {
+	echoPort := startEchoServer(t)
+
+	// Occupy the port the tunnel server will try to bind. This has to be a
+	// wildcard bind, matching what InitTunnel does: on macOS binding
+	// 0.0.0.0:P succeeds even while 127.0.0.1:P is held, so occupying only
+	// the loopback address would not conflict.
+	tunnelPort := freePort(t)
+	occupied, err := net.Listen("tcp", fmt.Sprintf(":%d", tunnelPort))
+	if err != nil {
+		t.Fatalf("failed occupying port %d: %v", tunnelPort, err)
+	}
+	defer func() { _ = occupied.Close() }()
+
+	_, clientHook := startTunnel(t, tunnelPort, echoPort)
+
+	// The client should report what the server told it.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		for _, entry := range clientHook.AllEntries() {
+			if strings.Contains(entry.Message, "tunnel server:") &&
+				strings.Contains(entry.Message, "failed opening listener") {
+				return // reported, as it should be
+			}
+		}
+		if time.Now().After(deadline) {
+			var seen []string
+			for _, e := range clientHook.AllEntries() {
+				seen = append(seen, e.Message)
+			}
+			t.Fatalf("the server's bind failure was never reported to the client.\n"+
+				"client logged:\n  %s", strings.Join(seen, "\n  "))
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// TestLoopback_UnparseableSessionIDIsSkipped guards the other half of the same
+// bug: a frame whose session ID cannot be parsed must be skipped, not acted on
+// with the zero UUID.
+func TestLoopback_UnparseableSessionIDIsSkipped(t *testing.T) {
+	echoPort := startEchoServer(t)
+	tunnelPort := freePort(t)
+	_, clientHook := startTunnel(t, tunnelPort, echoPort)
+
+	// Establish a working tunnel first, so we know the client is running.
+	conn := dialUntilReady(t, fmt.Sprintf("127.0.0.1:%d", tunnelPort), 10*time.Second)
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		t.Fatalf("failed writing: %v", err)
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatalf("failed setting deadline: %v", err)
+	}
+	buf := make([]byte, 64)
+	if _, err := conn.Read(buf); err != nil {
+		t.Fatalf("failed reading: %v", err)
+	}
+	_ = conn.Close()
+
+	// A healthy tunnel must never produce the parse failure.
+	for _, entry := range clientHook.AllEntries() {
+		if strings.Contains(entry.Message, "failed parsing session uuid") {
+			t.Fatalf("healthy tunnel logged a session uuid parse failure: %q", entry.Message)
+		}
+	}
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -18,51 +18,51 @@ const (
 	BufferSize = 1024 * 3
 )
 
-var openSessions = sync.Map{}
+// DefaultSessionReapDelay is how long a closed session stays in its store
+// before being removed. Frames for a session can still be in flight when it
+// closes, and dropping it immediately turns those into "session not found".
+const DefaultSessionReapDelay = 5 * time.Second
 
-type Session struct {
-	ID         uuid.UUID
-	Conn       net.Conn
-	Buf        bytes.Buffer
-	Context    context.Context
-	cancelFunc context.CancelFunc
-	Open       bool
-	sync.Mutex
+// SessionStore holds the open sessions for one side of a tunnel.
+//
+// This is per-side rather than process-global: a client and a server running
+// in the same process address sessions by the same UUIDs, so a shared store
+// would have each side finding the other's session instead of its own. In
+// production they are separate processes, but tests -- and any future
+// in-process use -- need them isolated.
+type SessionStore struct {
+	sessions sync.Map
+
+	// reapDelay is DefaultSessionReapDelay unless overridden; tests set it
+	// low so they do not wait out the delay.
+	reapDelay time.Duration
 }
 
-func (s *Session) Close() {
-	s.cancelFunc()
-	if s.Conn != nil {
-		_ = s.Conn.Close()
-		s.Open = false
+// NewSessionStore returns an empty store.
+func NewSessionStore() *SessionStore {
+	return &SessionStore{reapDelay: DefaultSessionReapDelay}
+}
+
+// SetReapDelay overrides how long closed sessions linger before removal.
+func (s *SessionStore) SetReapDelay(d time.Duration) {
+	s.reapDelay = d
+}
+
+// New registers a session for conn under a freshly generated ID.
+func (s *SessionStore) New(conn net.Conn) *Session {
+	return s.add(uuid.New(), conn)
+}
+
+// NewFromStream registers a session for conn under an ID chosen by the peer.
+// It returns an error if that ID is already in use.
+func (s *SessionStore) NewFromStream(id uuid.UUID, conn net.Conn) (*Session, error) {
+	if _, ok := s.Get(id); ok {
+		return nil, fmt.Errorf("session %s already exists", id.String())
 	}
-	go func() {
-		<-time.After(5 * time.Second)
-		openSessions.Delete(s.ID)
-	}()
+	return s.add(id, conn), nil
 }
 
-type RedirectRequest struct {
-	Source     int32
-	TargetHost string
-	TargetPort int32
-}
-
-func NewSession(conn net.Conn) *Session {
-	ctx, cancel := context.WithCancel(context.Background())
-	r := &Session{
-		ID:         uuid.New(),
-		Conn:       conn,
-		Context:    ctx,
-		cancelFunc: cancel,
-		Buf:        bytes.Buffer{},
-		Open:       true,
-	}
-	_, _ = addSession(r)
-	return r
-}
-
-func NewSessionFromStream(id uuid.UUID, conn net.Conn) *Session {
+func (s *SessionStore) add(id uuid.UUID, conn net.Conn) *Session {
 	ctx, cancel := context.WithCancel(context.Background())
 	r := &Session{
 		ID:         id,
@@ -71,25 +71,85 @@ func NewSessionFromStream(id uuid.UUID, conn net.Conn) *Session {
 		cancelFunc: cancel,
 		Buf:        bytes.Buffer{},
 		Open:       true,
+		store:      s,
 	}
-	_, _ = addSession(r)
+	s.sessions.Store(id, r)
 	return r
 }
 
-func addSession(r *Session) (bool, error) {
-	if _, ok := GetSession(r.ID); ok {
-		return false, fmt.Errorf("session %s already exists", r.ID.String())
+// Get returns the session with the given ID, if it is still present.
+func (s *SessionStore) Get(id uuid.UUID) (*Session, bool) {
+	session, ok := s.sessions.Load(id)
+	if !ok {
+		return nil, false
 	}
-	openSessions.Store(r.ID, r)
-	return true, nil
+	return session.(*Session), true
 }
 
-func GetSession(id uuid.UUID) (*Session, bool) {
-	request, ok := openSessions.Load(id)
-	if ok {
-		return request.(*Session), ok
+// Delete removes a session immediately.
+func (s *SessionStore) Delete(id uuid.UUID) {
+	s.sessions.Delete(id)
+}
+
+// Len reports how many sessions the store currently holds.
+func (s *SessionStore) Len() int {
+	n := 0
+	s.sessions.Range(func(_, _ interface{}) bool {
+		n++
+		return true
+	})
+	return n
+}
+
+type Session struct {
+	ID         uuid.UUID
+	Conn       net.Conn
+	Buf        bytes.Buffer
+	Context    context.Context
+	cancelFunc context.CancelFunc
+	Open       bool
+	store      *SessionStore
+	sync.Mutex
+}
+
+// IsOpen reports whether the session is still open.
+func (s *Session) IsOpen() bool {
+	s.Lock()
+	defer s.Unlock()
+	return s.Open
+}
+
+// SetOpen sets the session's open flag.
+func (s *Session) SetOpen(open bool) {
+	s.Lock()
+	defer s.Unlock()
+	s.Open = open
+}
+
+func (s *Session) Close() {
+	s.cancelFunc()
+
+	s.Lock()
+	if s.Conn != nil {
+		_ = s.Conn.Close()
+		s.Open = false
 	}
-	return nil, ok
+	s.Unlock()
+
+	if s.store == nil {
+		return
+	}
+	store, id := s.store, s.ID
+	go func() {
+		<-time.After(store.reapDelay)
+		store.Delete(id)
+	}()
+}
+
+type RedirectRequest struct {
+	Source     int32
+	TargetHost string
+	TargetPort int32
 }
 
 func ParsePorts(s string) (*RedirectRequest, error) {

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -1,0 +1,158 @@
+package common
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// pipeConn returns one end of an in-memory connection, closed on cleanup.
+func pipeConn(t *testing.T) net.Conn {
+	t.Helper()
+	a, b := net.Pipe()
+	t.Cleanup(func() {
+		_ = a.Close()
+		_ = b.Close()
+	})
+	return a
+}
+
+func TestSessionStore_NewAndGet(t *testing.T) {
+	store := NewSessionStore()
+	session := store.New(pipeConn(t))
+
+	got, ok := store.Get(session.ID)
+	if !ok {
+		t.Fatal("a session registered with New was not retrievable")
+	}
+	if got.ID != session.ID {
+		t.Errorf("got session %s, want %s", got.ID, session.ID)
+	}
+	if !got.IsOpen() {
+		t.Error("a new session should be open")
+	}
+}
+
+func TestSessionStore_GetMissing(t *testing.T) {
+	store := NewSessionStore()
+	if _, ok := store.Get(uuid.New()); ok {
+		t.Error("Get returned ok for an ID that was never registered")
+	}
+}
+
+func TestSessionStore_NewFromStreamRejectsDuplicates(t *testing.T) {
+	store := NewSessionStore()
+	id := uuid.New()
+
+	if _, err := store.NewFromStream(id, pipeConn(t)); err != nil {
+		t.Fatalf("first registration failed: %v", err)
+	}
+
+	// A peer reusing an ID must not silently replace the live session, which
+	// would strand the connection the first one owns.
+	if _, err := store.NewFromStream(id, pipeConn(t)); err == nil {
+		t.Error("expected an error when reusing a session ID, got nil")
+	}
+}
+
+// TestSessionStore_StoresAreIsolated is the property that lets a client and a
+// server run in the same process. Both sides address sessions by the same
+// UUIDs, so with a shared store each would find the other's session.
+func TestSessionStore_StoresAreIsolated(t *testing.T) {
+	serverSide := NewSessionStore()
+	clientSide := NewSessionStore()
+
+	session := serverSide.New(pipeConn(t))
+
+	if _, ok := clientSide.Get(session.ID); ok {
+		t.Fatal("a session registered in one store was visible in another")
+	}
+
+	// The other side registering the same ID must succeed, not collide.
+	if _, err := clientSide.NewFromStream(session.ID, pipeConn(t)); err != nil {
+		t.Errorf("the peer could not register its own view of the session: %v", err)
+	}
+}
+
+func TestSession_CloseReapsFromStore(t *testing.T) {
+	store := NewSessionStore()
+	store.SetReapDelay(10 * time.Millisecond)
+
+	session := store.New(pipeConn(t))
+	session.Close()
+
+	if session.IsOpen() {
+		t.Error("a closed session should not report itself open")
+	}
+
+	// Sessions linger briefly so that in-flight frames do not become
+	// "session not found"; after the delay they must actually be removed.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, ok := store.Get(session.ID); !ok {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("a closed session was never reaped from its store")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if n := store.Len(); n != 0 {
+		t.Errorf("store still holds %d sessions after reaping", n)
+	}
+}
+
+func TestSession_CloseIsSafeWithoutAStore(t *testing.T) {
+	// Sessions built outside a store must not panic on Close.
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Session{ID: uuid.New(), Context: ctx, cancelFunc: cancel}
+	s.Close()
+}
+
+func TestParsePorts(t *testing.T) {
+	cases := []struct {
+		name       string
+		in         string
+		wantSource int32
+		wantHost   string
+		wantPort   int32
+		wantErr    bool
+	}{
+		{name: "single port", in: "8000", wantSource: 8000, wantHost: "localhost", wantPort: 8000},
+		{name: "source and target", in: "80:8000", wantSource: 80, wantHost: "localhost", wantPort: 8000},
+		{name: "source host and target", in: "80:example.internal:8000", wantSource: 80, wantHost: "example.internal", wantPort: 8000},
+		{name: "empty", in: "", wantErr: true},
+		{name: "non-numeric source", in: "http:8000", wantErr: true},
+		{name: "non-numeric target", in: "80:http", wantErr: true},
+		{name: "non-numeric target with host", in: "80:example.internal:http", wantErr: true},
+		{name: "too many parts", in: "1:2:3:4", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParsePorts(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParsePorts(%q) succeeded, want an error", tc.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParsePorts(%q) failed: %v", tc.in, err)
+			}
+			if got.Source != tc.wantSource {
+				t.Errorf("source = %d, want %d", got.Source, tc.wantSource)
+			}
+			if got.TargetHost != tc.wantHost {
+				t.Errorf("target host = %q, want %q", got.TargetHost, tc.wantHost)
+			}
+			if got.TargetPort != tc.wantPort {
+				t.Errorf("target port = %d, want %d", got.TargetPort, tc.wantPort)
+			}
+		})
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -87,9 +87,18 @@ func ReceiveData(conf *Config, stream pb.Tunnel_InitTunnelServer) {
 				continue
 			}
 
-			session, ok := common.GetSession(reqID)
-			if !ok && !message.ShouldClose {
-				conf.log.WithField("session", reqID).Errorf("session not found in openRequests")
+			session, ok := conf.sessions.Get(reqID)
+			if !ok {
+				// A close frame for a session we have already reaped is
+				// expected -- sessions linger only briefly after closing --
+				// and there is nothing left to close. Anything else is a
+				// genuine mismatch. Either way there is no session to
+				// dereference below, so both must stop here.
+				if message.ShouldClose {
+					conf.log.WithField("session", reqID).Debug("close for an already-closed session, ignoring")
+				} else {
+					conf.log.WithField("session", reqID).Errorf("session not found in openRequests")
+				}
 				continue
 			}
 
@@ -102,7 +111,7 @@ func ReceiveData(conf *Config, stream pb.Tunnel_InitTunnelServer) {
 			}).Debugf("received %d bytes from client", len(data))
 
 			// send data if we received any
-			if br > 0 && session.Open {
+			if br > 0 && session.IsOpen() {
 				conf.log.WithField("session", reqID).Debugf("writing %d bytes to conn", br)
 				_, err := session.Conn.Write(data)
 				if err != nil {
@@ -158,7 +167,7 @@ func readConn(ctx context.Context, conf *Config, session *common.Session, sessio
 			session.Unlock()
 
 			sessions <- session
-			if !session.Open {
+			if !session.IsOpen() {
 				return
 			}
 		}
@@ -230,7 +239,7 @@ func (t *TunnelServer) InitTunnel(stream pb.Tunnel_InitTunnelServer) error {
 		}
 
 		// socket -> stream
-		session := common.NewSession(connection)
+		session := t.conf.sessions.New(connection)
 		go readConn(stream.Context(), t.conf, session, sessions)
 	}
 }
@@ -285,6 +294,10 @@ func processArgs(opts []Option) (*Config, error) {
 		}
 	}
 
+	if opt.sessions == nil {
+		opt.sessions = common.NewSessionStore()
+	}
+
 	return opt, nil
 }
 
@@ -329,4 +342,14 @@ type Config struct {
 	keyFile  string
 	log      log.FieldLogger
 	certFile string
+	sessions *common.SessionStore
+}
+
+// WithSessionStore sets the store this server tracks its sessions in. If
+// unset, the server creates its own.
+func WithSessionStore(store *common.SessionStore) Option {
+	return func(opt *Config) error {
+		opt.sessions = store
+		return nil
+	}
 }


### PR DESCRIPTION
The remaining four v2.0.0 items. With these, everything scoped for the
release is done.

`pkg/client`, `pkg/server` and `pkg/common` had **no test files at all**,
so every fix here would otherwise have been a fix by inspection. The
tests came with them.

## Report what the server actually said — #88, #66, #143

The client never read `SocketDataResponse.HasErr` or `.LogMessage`. When
the in-cluster server fails to bind its listener it sends a frame saying
exactly why — but that frame carries **no session ID**, because it isn't
about a session. The client failed to parse the empty ID, logged
`failed parsing session uuid from stream, skipping`, **did not skip**,
and carried on with the zero UUID to open a bogus session.

The famous `invalid UUID length: 0` was never the bug. It was a real,
actionable error — usually a port conflict or a permission denial —
being thrown away and replaced with nonsense.

Reverting just the client fix makes the new test reproduce the reported
logs exactly:

```
failed parsing session uuid from stream, skipping
new connection            ← it did not skip
received 0 bytes from server
```

…with the server's actual message (`failed opening listener type TCP on
port 57101: address already in use`) nowhere to be seen.

## Stop panicking on a close for a reaped session

`server.ReceiveData` guarded with `if !ok && !message.ShouldClose` and
then dereferenced `session.ID` on the **very next line**. A close frame
for a session already removed from the store — sessions linger only
briefly after closing — took the whole tunnel server pod down with a nil
pointer dereference.

## Let Ctrl+C interrupt the wait for readiness

`expose` and `inject` received on `readyChan` directly with no escape.
The signal handler ran on another goroutine, logged "Got exit signal",
tore down the resources, then blocked because nothing consumed `done` —
while the main goroutine sat on `readyChan`. `waitForReady` now selects
on the context the handler cancels.

`expose` also no longer *ignores* a failed rollout and proceeds to
port-forward regardless — it discarded the bool entirely.

## Make the session store per-side rather than process-global

`openSessions` was a package-level `sync.Map` shared by both roles. A
client and a server in one process address sessions by the same UUIDs,
so each found the other's session instead of its own. **This is why
there could be no end-to-end test.**

`SessionStore` is now created per side and threaded through both
`Config`s via `WithSessionStore`. `Session.Open` access also goes
through the mutex via `IsOpen`/`SetOpen`; it was read and written
unsynchronised.

## Tests

`pkg/client/loopback_test.go` runs a **real server and a real client
over real TCP** and pushes bytes end to end — echo round trip,
sequential connections, the bind-failure report, and a healthy tunnel
never logging a parse failure. `pkg/common` covers the store and
`ParsePorts`; `cmd` covers `waitForReady` including the interrupt that
used to hang.

Coverage, all from zero: **pkg/common 88.9%, pkg/client 68.0%, cmd 22.0%**.

`go test -race`, `go vet`, `gofmt -l` and `gosec` all clean.

## Note on the API

`WithSessionStore` is additive and optional — both sides create their
own store when it isn't set, so existing callers are unaffected. The
previously exported `common.NewSession`, `common.NewSessionFromStream`
and `common.GetSession` are replaced by methods on `SessionStore`. They
were only ever used by this repo's own client and server.