### PR TITLE
Keep prereleases from leaking outside the repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
+      # Prereleases must not reach krew-index: the bot opens a pull request
+      # against kubernetes-sigs/krew-index, a third-party repository, and a
+      # release candidate has no business being advertised there. Semver
+      # prerelease tags always carry a hyphen (v2.0.0-rc1).
       - name: Update new version in krew-index
+        if: ${{ !contains(github.ref_name, '-') }}
         uses: rajatjindal/krew-release-bot@v0.0.47
 
   image:
@@ -114,7 +119,9 @@ jobs:
           # cmd/expose.go builds as the default --server-image.
           tags: |
             type=ref,event=tag
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            # `latest` must never point at a release candidate, so it is
+            # gated on the tag having no prerelease suffix.
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
             type=raw,value=edge,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
             type=sha,format=short
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -134,12 +134,24 @@ Watch the run under **Actions**. Confirm all three of:
 docker run --rm docker.io/omrieival/ktunnel:v2.0.0-rc1 version
 ```
 
-One thing a prerelease deliberately does *not* exercise: the Homebrew
-tap. `prerelease: auto` skips the tap update for rc tags, which is the
-point — rehearsals should not publish a formula. So the tap push is only
-ever proven by a real release. If `HOMEBREW_TAP_GITHUB_TOKEN` is wrong,
-you find out on the real tag, and the failure is silent. Double-check
-the token's repository scope when you create it.
+Three things a prerelease deliberately does *not* do, so that a
+rehearsal has no effect on the outside world:
+
+- **It does not update the Homebrew tap.** `prerelease: auto` skips the
+  formula for rc tags.
+- **It does not open a krew-index pull request.** The krew bot opens a
+  PR against `kubernetes-sigs/krew-index`, a third-party repository, and
+  a release candidate has no business being advertised there.
+- **It does not move the `latest` container tag.** `latest` is gated on
+  the tag having no prerelease suffix.
+
+All three are keyed on the hyphen that semver prerelease tags carry, so
+name rehearsal tags accordingly — `v2.0.0-rc1`, not `v2.0.0rc1`.
+
+The flip side: because the tap is skipped, the tap push is only ever
+proven by a real release. If `HOMEBREW_TAP_GITHUB_TOKEN` is wrong you
+find out on the real tag, and the failure is silent. Double-check the
+token's repository scope when you create it.
 
 If anything failed, delete the tag and the draft release, fix, repeat:
 


### PR DESCRIPTION
Found while getting ready to rehearse with `v2.0.0-rc1`. A rehearsal is
supposed to be inert. Two steps were not gated on the tag being a real
release, so an rc tag would have:

1. **Opened a pull request against `kubernetes-sigs/krew-index`** —
   a third-party repository — advertising a release candidate as an
   installable plugin version.
2. **Moved the `latest` container tag** on both Docker Hub and ghcr to
   point at the release candidate.

The second is the worse one: it affects users who never asked for a
prerelease and just pull `latest`.

Both are now gated on the tag carrying no prerelease suffix, which is
the same thing goreleaser's `prerelease: auto` already does for the
Homebrew tap. All three key off the hyphen that semver prerelease tags
carry, so rehearsal tags need to be named `v2.0.0-rc1`, not `v2.0.0rc1`.

`RELEASING.md` now states all three explicitly, along with the flip
side: because the tap is skipped for prereleases, the tap push is only
ever proven by a real release, so a wrong `HOMEBREW_TAP_GITHUB_TOKEN`
fails silently on the real tag.