### PR TITLE
Stop metadata-action tagging prereleases as latest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,6 +115,13 @@ jobs:
           images: |
             docker.io/omrieival/ktunnel
             ghcr.io/${{ github.repository }}
+          # metadata-action defaults to `latest=auto`, which adds `latest` on
+          # any tag event *independently* of the tags list below -- so an
+          # `enable=false` on the explicit entry is not enough to stop it, as
+          # v2.0.0-rc1 demonstrated. Turning the automatic behaviour off makes
+          # the guarded entry below the only thing that can set `latest`.
+          flavor: |
+            latest=false
           # `type=ref,event=tag` produces v2.0.0, which is exactly what
           # cmd/expose.go builds as the default --server-image.
           tags: |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -143,7 +143,11 @@ rehearsal has no effect on the outside world:
   PR against `kubernetes-sigs/krew-index`, a third-party repository, and
   a release candidate has no business being advertised there.
 - **It does not move the `latest` container tag.** `latest` is gated on
-  the tag having no prerelease suffix.
+  the tag having no prerelease suffix. Note that this needs *both* the
+  guard on the `type=raw,value=latest` entry and `flavor: latest=false`:
+  metadata-action defaults to `latest=auto`, which adds `latest` on any
+  tag event independently of the tags list. v2.0.0-rc1 moved `latest`
+  because only the first of those two was in place.
 
 All three are keyed on the hyphen that semver prerelease tags carry, so
 name rehearsal tags accordingly — `v2.0.0-rc1`, not `v2.0.0rc1`.


### PR DESCRIPTION
The guard in #159 was necessary but not sufficient. Pushing
`v2.0.0-rc1` **moved `latest` on both registries to the release
candidate** — exactly what that change was meant to prevent.

Caught by verifying the rehearsal rather than trusting it:

```
TAG           LAST UPDATED                 DIGEST
latest        2026-08-28T18:36:26.367819Z  sha256:e20847b6e238dc430
v2.0.0-rc1    2026-08-28T18:36:22.627058Z  sha256:e20847b6e238dc430
```

## Cause

`docker/metadata-action` defaults to `flavor: latest=auto`, which adds
`latest` on any tag event **independently of the tags list**. The run
log shows both halves:

```
type=raw,value=latest,enable=false     ← our guard, correctly false
Processing flavor input
latest=auto                            ← the default, which won
docker.io/***/ktunnel:latest           ← pushed regardless
```

So `enable=false` on the explicit entry was never going to be enough.

## Fix

`flavor: latest=false` turns the automatic behaviour off, leaving the
guarded entry as the only thing that can set `latest`.

## Remediation

None needed for the tag already pushed. `v2.0.0-rc1` is built from the
same commit `v2.0.0` will be, so tagging the real release repoints
`latest` at byte-identical content. The bug would have mattered on any
*future* prerelease made from a commit ahead of the last stable one.

The krew-index half of #159 worked correctly — that step shows
`skipped` in the rc1 run.