### PR TITLE
Fix the Homebrew tap token template, release as v2.0.2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -99,12 +99,14 @@ brews:
   - repository:
       owner: omrikiei
       name: homebrew-ktunnel
-      # Publishing to the tap needs a PAT with write access to
-      # omrikiei/homebrew-ktunnel; the workflow's default GITHUB_TOKEN is
-      # scoped to this repo only. Without the secret the formula is still
-      # built into dist/ and the release itself succeeds.
-      token: "{{ if index .Env \"HOMEBREW_TAP_GITHUB_TOKEN\" }}{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}{{ end }}"
-    skip_upload: '{{ if index .Env "HOMEBREW_TAP_GITHUB_TOKEN" }}auto{{ else }}true{{ end }}'
+      # Must be exactly `{{ .Env.VAR }}` -- goreleaser rejects any
+      # conditional or surrounding text here with "expected
+      # {{ .Env.VAR_NAME }} only (no plain-text or other interpolation)",
+      # and it rejects it at publish time, after the release is already
+      # out. The secret is required; see RELEASING.md.
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    # `auto` skips the tap for prerelease tags (e.g. v2.1.0-rc1).
+    skip_upload: auto
     commit_author:
       name: omrikiei
       email: omrieival@gmail.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v2.0.2
+
+Packaging fix. Functionally identical to v2.0.1 — same code, same
+container image contents.
+
+v2.0.1 published its GitHub release and container images correctly, but
+the Homebrew tap update failed on a configuration error: goreleaser
+requires the tap `token` field to be exactly `{{ .Env.VAR }}` and
+rejects anything else, including a conditional. It rejects it at
+*publish* time, after the release is already out, so the release
+succeeded and the packaging did not. The krew-index update was then
+skipped because the job had already failed.
+
+If you installed v2.0.1 from a GitHub release or a container registry,
+there is no reason to upgrade. If you install via Homebrew or krew,
+v2.0.2 is the first version you will see.
+
 ## v2.0.1
 
 The first release since v1.6.1 (September 2023). It carries about two

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -219,6 +219,22 @@ The archive name template in `.goreleaser.yml` is also load-bearing:
 `.krew.yaml` and `ktunnel.rb` both construct download URLs from it.
 Changing it breaks krew and Homebrew installs.
 
+## A failed publish does not roll back the release
+
+goreleaser publishes the GitHub release *before* it updates the Homebrew
+tap, and validates the tap configuration at publish time rather than up
+front. A mistake there — v2.0.1 hit `expected {{ .Env.VAR_NAME }} only
+(no plain-text or other interpolation)` from a conditional in the tap
+`token` field — fails the job with the release already public, and the
+krew-index step skipped along with it.
+
+`goreleaser check` does not catch this; it validates schema, not
+template shape. If you change anything under `brews:`, the only real
+verification is a release.
+
+Recovering means fixing forward with a new patch tag. The published tag
+cannot be reused, and re-pushing it would be worse than a version bump.
+
 ## Known deprecation
 
 `brews` is deprecated in goreleaser in favour of `homebrew_casks`. It

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,7 +13,7 @@ import (
 // goreleaser via -ldflags "-X github.com/omrikiei/ktunnel/cmd.version=...",
 // so that the binary, the git tag and the default --server-image tag
 // always agree. The literal here is only used for local builds.
-var version = "2.0.1"
+var version = "2.0.2"
 
 var port int
 var tls bool

--- a/docs/ktunnel_expose.md
+++ b/docs/ktunnel_expose.md
@@ -46,7 +46,7 @@ ktunnel expose redis 6379
       --server-cpu-limit int             Server container CPU Limit in milli-cpus (default 500)
       --server-cpu-request int           Server container CPU Request in milli-cpus (default 100)
   -o, --server-host-override string      Server name use to verify the hostname returned by the TLS handshake
-  -i, --server-image string              Ktunnel server image to use (default "docker.io/omrieival/ktunnel:v2.0.1")
+  -i, --server-image string              Ktunnel server image to use (default "docker.io/omrieival/ktunnel:v2.0.2")
       --server-memory-limit int          Server container CPU Limit in mega-bytes (default 1000)
       --server-memory-request int        Server container CPU Request in mega-bytes (default 100)
       --service-type string              exposed service type (ClusterIP, NodePort, LoadBalancer or ExternalName) (default "ClusterIP")

--- a/docs/ktunnel_inject_deployment.md
+++ b/docs/ktunnel_inject_deployment.md
@@ -27,7 +27,7 @@ ktunnel inject deployment mydeployment 3306 6379
   -n, --namespace string              Namespace (default "default")
   -s, --scheme string                 Connection scheme (default "tcp")
   -o, --server-host-override string   Server name use to verify the hostname returned by the TLS handshake
-  -i, --server-image string           Ktunnel server image to use (default "docker.io/omrieival/ktunnel:v2.0.1")
+  -i, --server-image string           Ktunnel server image to use (default "docker.io/omrieival/ktunnel:v2.0.2")
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
v2.0.1 published its GitHub release and container images correctly, then
failed on the last step:

```
homebrew formula: expected {{ .Env.VAR_NAME }} only
(no plain-text or other interpolation)
```

## Cause

I wrote the tap `token` field as a conditional so a missing secret would
degrade gracefully:

```yaml
token: "{{ if index .Env \"HOMEBREW_TAP_GITHUB_TOKEN\" }}{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}{{ end }}"
```

goreleaser accepts nothing but a bare `{{ .Env.VAR }}` there. Graceful
degradation isn't worth a config form the tool rejects — the token is
now simply required, which is how the pipeline already treats the Docker
Hub credentials.

## Why this cost a version

goreleaser validates the tap config at **publish** time, and publishes
the GitHub release *before* touching the tap. So the release went out,
the tap did not, and the krew-index step was skipped because the job had
already failed. `goreleaser check` does not catch it — it validates
schema, not template shape.

The published tag can't be reused and re-pushing it would be worse than
a version bump, so this fixes forward. **v2.0.2 is functionally
identical to v2.0.1** — same code, same image contents. Anyone who
installed from a GitHub release or a registry has no reason to upgrade;
Homebrew and krew users will see v2.0.2 as their first version.

## What was verified working in v2.0.1

- release published with all 11 assets, not draft, not prerelease
- images pushed to both registries
- **`latest` correctly moved to the real release** — the first live test
  of #161, which a prerelease could not exercise

`RELEASING.md` now records that a failed publish leaves the release out
and requires fixing forward.