### PR TITLE
Stop Test_newContainer leaking verbose state between runs

### DIFF
--- a/pkg/k8s/common_test.go
+++ b/pkg/k8s/common_test.go
@@ -71,9 +71,13 @@ func Test_newContainer(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.verbose {
-				SetVerbose(true)
-			}
+			// verbose is package-level state that newContainer reads, so it
+			// has to be set for every case and restored afterwards. Setting
+			// it only for the verbose case leaked into subsequent runs of the
+			// same binary, which made `go test -count=2` fail with a stray
+			// -v argument -- and made the flag unusable for flake detection.
+			SetVerbose(tc.verbose)
+			t.Cleanup(func() { SetVerbose(false) })
 
 			container := newContainer(tc.port, tc.image, tc.containerPorts, tc.cert, tc.key, tc.cReq, tc.cLimit, tc.mReq, tc.mLimit)
 


### PR DESCRIPTION
`newContainer` reads package-level verbose state to decide whether to
append `-v`. The table test set it for the verbose case and never
restored it — and since that case is last in the table, a single run
passes.

With `-count=2` the second iteration starts with verbose still on, so
every case gets a stray argument:

```
--- FAIL: Test_newContainer/basic_container
    Expected 3 args, got 4
--- FAIL: Test_newContainer/container_with_certs
    Expected arg --cert /certs/tls.crt at position 3, got -v
```

The effect is worse than one failing test: **`-count>1` was unusable on
`pkg/k8s`**, which is exactly the flag you reach for to detect flaky
tests. That matters more now that concurrency-sensitive code is being
added elsewhere in the repo.

Fix is to set verbose per case and restore it with `t.Cleanup`.

```
$ go test -race -count=5 ./...
ok  cmd  pkg/client  pkg/common  pkg/k8s     (all pass)
```

Found while reviewing unrelated work; the bug predates it and reproduces
on master.

Worth noting for later: the underlying cause is that `verbose` is
package-global mutable state read at container-construction time. The
test fix is correct and sufficient, but threading it through explicitly
would remove the class of problem rather than this instance.