### PR TITLE
Move to Go 1.26

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
           cache: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
           cache: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 ENV GO111MODULE=on
 RUN apk update && \
     apk add upx

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/omrikiei/ktunnel
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
Go supports the two most recent major releases. **go1.27.0 and go1.26.7
are both stable**, so 1.25 no longer receives security fixes.

All four pins move together — `go.mod`, the `Dockerfile`, and both
workflows. Letting them drift is exactly what left the server image
unbuildable before v2.0.1: the Dockerfile sat on `golang:1.19` while
`go.mod` required 1.22, and nothing caught it because the image was only
built on tags. It is now built on every PR, so this change is checked
before it can reach a release.

## Verified on 1.26.0

- `go build`, `go vet`, `gofmt -l` — clean
- `gosec` — 0 issues across 21 files
- `go test -race -count=2 ./...` — all six packages pass
- `docker build` from `golang:1.26-alpine` succeeds, and the resulting
  image runs and reports its version

## Note

This targets 1.26 as requested. 1.27 is also stable and would buy a
longer runway before the next forced bump — happy to retarget if
preferred; the change is the same four lines.