### PR TITLE
Move to Go 1.27

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version: '1.27'
           check-latest: true
           cache: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version: '1.27'
           check-latest: true
           cache: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine AS builder
+FROM golang:1.27-alpine AS builder
 ENV GO111MODULE=on
 RUN apk update && \
     apk add upx

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/omrikiei/ktunnel
 
-go 1.26.0
+go 1.27.0
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
go1.27.0 is the current stable release. Go supports the two most recent releases, so 1.26 is fine and 1.25 — where this repo sat until yesterday — was already out of support. This gets us to the front of that window rather than the back of it.

Bumps all four pins together, which is the whole point:

- `go.mod` → `go 1.27.0`
- `Dockerfile` → `FROM golang:1.27-alpine AS builder`
- `go-version: '1.27'` in `.github/workflows/test.yml`
- `go-version: '1.27'` in `.github/workflows/release.yaml`

These drifted apart before — a `golang:1.19` base image building a module that required 1.22 — and that kind of skew stays invisible until something breaks, because the image build only ran on tags.

## Verification

On go1.27.0 locally (arm64):

- `go build ./...` — clean
- `go vet ./...` — clean
- `gofmt -l .` — empty
- `gosec -exclude-dir=.git -exclude-dir=vendor ./...` — 0 issues, 21 files, 4258 lines
- `go test -race -count=2 ./...` — all six packages pass

The check that matters here is **Build and publish container image**, since this changes the base image and CI builds both `linux/amd64` and `linux/arm64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)