### PR TITLE
Stop expose printing a cleanup error on every clean Ctrl+C

### DIFF
--- a/pkg/k8s/cleanup.go
+++ b/pkg/k8s/cleanup.go
@@ -3,10 +3,7 @@ package k8s
 
 import (
 	"context"
-	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -157,30 +154,6 @@ func (rt *ResourceTracker) Cleanup(ctx context.Context) error {
 		}
 		return nil
 	}
-}
-
-// StartCleanupOnSignal starts a goroutine that will clean up resources when a shutdown signal is received
-func (rt *ResourceTracker) StartCleanupOnSignal() {
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-
-	go func() {
-		sig := <-sigChan
-		log.Infof("Received %v signal, cleaning up resources...", sig)
-
-		ctx := context.Background()
-		if err := rt.Cleanup(ctx); err != nil {
-			if err == context.DeadlineExceeded {
-				log.Errorf("Cleanup timed out after %v", rt.timeout)
-			} else {
-				log.Errorf("Failed to clean up resources: %v", err)
-			}
-			os.Exit(1)
-		}
-
-		log.Info("Cleanup completed successfully")
-		os.Exit(0)
-	}()
 }
 
 // GetTrackedResources returns the currently tracked resources (useful for testing)

--- a/pkg/k8s/exposer.go
+++ b/pkg/k8s/exposer.go
@@ -115,7 +115,6 @@ func (k *KubeService) ExposeAsService(
 		}
 		deploymentCreated = true
 		tracker.AddDeployment(name)
-		tracker.StartCleanupOnSignal()
 	}
 	if !deploymentCreated && Reuse {
 		// Copy annotations, labels and selectors to prevent PATCH issue with immutable fields
@@ -196,17 +195,23 @@ func (k *KubeService) ExposeAsService(
 	return nil
 }
 
+// TeardownExposedService deletes the deployment and service that expose
+// created. It is idempotent: a resource that is already gone is not an error,
+// because teardown races with anything else that may have removed it -- a
+// `kubectl delete` from another terminal, or a previous teardown of the same
+// session -- and reporting "not found" as a failure sends the user looking for
+// resources that were, in fact, cleaned up.
 func (k *KubeService) TeardownExposedService(name string, DeploymentOnly bool) error {
 	if !DeploymentOnly {
 		log.Infof("Deleting service %s", name)
 		err := k.clients.Services.Delete(context.Background(), name, v1.DeleteOptions{})
-		if err != nil {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}
 	log.Infof("Deleting deployment %s", name)
 	err := k.clients.Deployments.Delete(context.Background(), name, v1.DeleteOptions{})
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 	return nil

--- a/pkg/k8s/teardown_test.go
+++ b/pkg/k8s/teardown_test.go
@@ -1,0 +1,81 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+)
+
+// kubeServiceWithExposed returns a KubeService backed by a fake API server
+// already holding the deployment and service that `expose` would have created.
+func kubeServiceWithExposed(name string) *KubeService {
+	fake := testclient.NewSimpleClientset(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		},
+		&v1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		},
+	)
+	return &KubeService{clients: &Clients{
+		Deployments: fake.AppsV1().Deployments("default"),
+		Services:    fake.CoreV1().Services("default"),
+	}}
+}
+
+// TestTeardownExposedService_IsIdempotent is the regression test for a red
+// ERROR line printed on every clean Ctrl+C of `ktunnel expose`.
+//
+// Two independent signal handlers used to race to delete the same deployment
+// and service: the one ResourceTracker installed, and the one the tunnel
+// session installs. Whichever lost reported `Failed deleting k8s objects:
+// services "..." not found` -- an error for work that had in fact succeeded,
+// which is precisely the "vague errors" complaint in #134.
+//
+// The duplicate handler is gone, and teardown is idempotent besides, so that
+// anything else removing the resources first -- a `kubectl delete` from
+// another terminal -- is not reported as a failure either.
+func TestTeardownExposedService_IsIdempotent(t *testing.T) {
+	svc := kubeServiceWithExposed("ktunnel-test")
+
+	if err := svc.TeardownExposedService("ktunnel-test", false); err != nil {
+		t.Fatalf("first teardown: unexpected error: %v", err)
+	}
+
+	// Everything is gone now, so a second teardown finds nothing. That has to
+	// be a success, not an error.
+	if err := svc.TeardownExposedService("ktunnel-test", false); err != nil {
+		t.Fatalf("second teardown reported failure for resources already gone: %v", err)
+	}
+
+	// And the resources really are gone -- an idempotent teardown must not be
+	// idempotent by way of never deleting anything.
+	if _, err := svc.clients.Deployments.Get(context.Background(), "ktunnel-test", metav1.GetOptions{}); err == nil {
+		t.Error("deployment still exists after teardown")
+	}
+	if _, err := svc.clients.Services.Get(context.Background(), "ktunnel-test", metav1.GetOptions{}); err == nil {
+		t.Error("service still exists after teardown")
+	}
+}
+
+// TestTeardownExposedService_DeploymentOnlyLeavesService covers the
+// --deployment-only path: the service belongs to the user, not to ktunnel, so
+// teardown must not touch it.
+func TestTeardownExposedService_DeploymentOnlyLeavesService(t *testing.T) {
+	svc := kubeServiceWithExposed("ktunnel-test")
+
+	if err := svc.TeardownExposedService("ktunnel-test", true); err != nil {
+		t.Fatalf("teardown: unexpected error: %v", err)
+	}
+
+	if _, err := svc.clients.Deployments.Get(context.Background(), "ktunnel-test", metav1.GetOptions{}); err == nil {
+		t.Error("deployment still exists after teardown")
+	}
+	if _, err := svc.clients.Services.Get(context.Background(), "ktunnel-test", metav1.GetOptions{}); err != nil {
+		t.Errorf("DeploymentOnly teardown deleted a service it does not own: %v", err)
+	}
+}


### PR DESCRIPTION
Found while running the manual verification gate for v2.1 against a real cluster — the reconnect path we couldn't test automatically. This is a different bug I hit on the way.

## The bug

Every clean `Ctrl+C` of `ktunnel expose` prints a red error for work that succeeded:

```
INFO Got exit signal, closing client tunnels and removing k8s objects
INFO Deleting service ktunnel-sigint-svc
INFO Deleted service ktunnel-sigint-svc
ERRO Failed deleting k8s objects: services "ktunnel-sigint-svc" not found
```

The resources *are* cleaned up. The error is false, and it reproduces every time, not intermittently.

## Cause

Two independent SIGINT handlers race to delete the same deployment and service:

1. `ResourceTracker.StartCleanupOnSignal()`, installed by `ExposeAsService` when it creates the deployment
2. the tunnel session handler installed by `newTunnelSession`, whose teardown callback calls `TeardownExposedService`

Whichever loses finds the resources already gone and reports it as a failure.

## Fix

**Remove the tracker's handler.** It was strictly the weaker of the two paths, so coordinating them isn't worth it — the session handler is a superset:

| | tracker handler | session handler |
|---|---|---|
| Signals | SIGINT, SIGTERM | SIGINT, SIGTERM, **SIGQUIT** |
| Second Ctrl+C | swallowed | handed back to the runtime |
| Exit code | calls `os.Exit(0)`/`os.Exit(1)` itself | leaves it to the supervisor |
| Knows `--reuse` / `--deployment-only` | no | yes |

The `os.Exit` is the part that mattered beyond the log line: it could pre-empt the session's teardown midway and override the exit code the supervisor intended to return.

**Make `TeardownExposedService` idempotent.** A resource already gone is not a failure — teardown also races with a `kubectl delete` from another terminal, and that shouldn't be reported as a failed cleanup either. This directly addresses the "vague errors" complaint in #134.

## Verification

Against a kind cluster (k8s v1.37.0), before and after:

- before — `ERRO Failed deleting k8s objects` on every clean exit
- after — teardown deletes both objects, **0 error lines**, exit code **0**, nothing left in the cluster

Plus `pkg/k8s/teardown_test.go`: teardown is idempotent, actually deletes (not idempotent by never deleting), and `--deployment-only` leaves the user's service alone.

Full suite: `go test -race -count=2 ./...` green across all six packages, `gosec` 0 issues, `go vet` and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)