### PR TITLE
Prepare v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v2.1.0
 
 A tunnel that loses its connection now comes back on its own.
 
@@ -153,6 +153,18 @@ fails. Reconnect on failure rather than trusting an idle socket.
   unit or a CI step saw success for a tunnel server that never started.
   Cluster resources created by the failed run are still cleaned up
   first.
+
+- **`expose` no longer reports a cleanup failure for a cleanup that
+  worked.** Two signal handlers raced to delete the same deployment and
+  service -- one installed by the resource tracker, one by the tunnel
+  session -- and whichever lost the race logged `Failed deleting k8s
+  objects: services "..." not found` on every clean Ctrl+C, for work that
+  had in fact succeeded. The tracker's handler is gone rather than
+  coordinated with: it called `os.Exit` itself, so it could also cut the
+  session's teardown short and override the exit code the supervisor
+  meant to return, and it handled a strictly smaller set of signals.
+  Teardown is idempotent besides, so a `kubectl delete` from another
+  terminal is not reported as a failed cleanup either.
 
 ### Known issues
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,7 +17,7 @@ repository secret**.
 | `GITHUB_TOKEN` | — | GitHub, automatically | Nothing. Never create this one. |
 | `DOCKERHUB_USERNAME` | **Yes** | You | Tagged releases fail fast, by design. Currently set and working. |
 | `DOCKERHUB_TOKEN` | **Yes** | You | Same. Currently set and working. |
-| `HOMEBREW_TAP_GITHUB_TOKEN` | Recommended | You | Release succeeds, but the Homebrew tap silently stays on the previous version. **Not yet set.** |
+| `HOMEBREW_TAP_GITHUB_TOKEN` | Recommended | You | Release succeeds, but the Homebrew tap silently stays on the previous version. Currently set and working. |
 | `CODECOV_TOKEN` | Optional | You | Coverage upload is skipped. CI still passes. |
 
 ### `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,7 +13,7 @@ import (
 // goreleaser via -ldflags "-X github.com/omrikiei/ktunnel/cmd.version=...",
 // so that the binary, the git tag and the default --server-image tag
 // always agree. The literal here is only used for local builds.
-var version = "2.0.2"
+var version = "2.1.0"
 
 var port int
 var tls bool

--- a/docs/ktunnel_expose.md
+++ b/docs/ktunnel_expose.md
@@ -48,7 +48,7 @@ ktunnel expose redis 6379
       --server-cpu-limit int             Server container CPU Limit in milli-cpus (default 500)
       --server-cpu-request int           Server container CPU Request in milli-cpus (default 100)
   -o, --server-host-override string      Server name use to verify the hostname returned by the TLS handshake
-  -i, --server-image string              Ktunnel server image to use (default "docker.io/omrieival/ktunnel:v2.0.2")
+  -i, --server-image string              Ktunnel server image to use (default "docker.io/omrieival/ktunnel:v2.1.0")
       --server-memory-limit int          Server container CPU Limit in mega-bytes (default 1000)
       --server-memory-request int        Server container CPU Request in mega-bytes (default 100)
       --service-type string              exposed service type (ClusterIP, NodePort, LoadBalancer or ExternalName) (default "ClusterIP")

--- a/docs/ktunnel_inject_deployment.md
+++ b/docs/ktunnel_inject_deployment.md
@@ -29,7 +29,7 @@ ktunnel inject deployment mydeployment 3306 6379
   -n, --namespace string              Namespace (default "default")
   -s, --scheme string                 Connection scheme (default "tcp")
   -o, --server-host-override string   Server name use to verify the hostname returned by the TLS handshake
-  -i, --server-image string           Ktunnel server image to use (default "docker.io/omrieival/ktunnel:v2.0.2")
+  -i, --server-image string           Ktunnel server image to use (default "docker.io/omrieival/ktunnel:v2.1.0")
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Release prep. No behaviour change beyond the version string.

- Releases the `## Unreleased` changelog section as `## v2.1.0`, and adds the teardown fix from #170 to its **Fixed** list.
- Bumps the version literal in `cmd/root.go` to `2.1.0`. The released binary takes its version from the git tag via ldflags, so the literal only affects local `go build` — but it also seeds the default `--server-image` tag, which is why the regenerated docs now read `docker.io/omrieival/ktunnel:v2.1.0`.
- `RELEASING.md` still described `HOMEBREW_TAP_GITHUB_TOKEN` as "Not yet set". It was set before v2.0.2, and the tap took that release on 2026-08-28.

## After this merges

`RELEASING.md` says to rehearse with a prerelease tag after any change to the pipeline, and #169 changed `release.yaml` (setup-go 1.26 → 1.27). So: `v2.1.0-rc1` first, verify the three publish paths, then `v2.1.0`.

## Manual verification gate

v2.1's headline feature is reconnecting a port-forward against a *renamed* pod, and that path has no automated test — it cannot be exercised without a real API server. It was run by hand against a kind cluster (k8s v1.37.0) before cutting this:

| Scenario | Result |
|---|---|
| `expose`, then curl the Service from inside the cluster | reaches the local server |
| `kubectl delete pod` on the tunnel server | forward rebuilt against the new pod name, **1.07s** end to end |
| curl again after the reconnect | reaches the local server |
| scale to 0, leave it down | backoff escalates 2.4 → 3.7 → 8.1 → 17.7s; reports `no running pods to forward to` instead of panicking |
| scale back to 1 | tunnel re-establishes, traffic flows |
| Ctrl+C | both objects deleted, 0 error lines, exit code 0, nothing left behind |

No panics anywhere in the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)