### PR TITLE
Pin goreleaser to the tag that triggered the release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          # Without this, goreleaser resolves the version from the git history
+          # rather than the tag that triggered the run -- and when two tags sit
+          # on one commit it can pick the wrong one. v2.1.0 was tagged on the
+          # same commit as its v2.1.0-rc1 rehearsal, so goreleaser rebuilt
+          # rc1, tried to upload assets that were already on the rc1 release,
+          # and failed with 422 already_exists. The real release was never
+          # built. Pin it to the triggering ref.
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
       # Prereleases must not reach krew-index: the bot opens a pull request
       # against kubernetes-sigs/krew-index, a third-party repository, and a

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -122,6 +122,17 @@ git tag v2.1.0-rc1
 git push origin v2.1.0-rc1
 ```
 
+> **Put the rehearsal tag on its own commit, never the commit you intend
+> to tag as the real release.** Two tags on one commit is ambiguous, and
+> it cost v2.1.0 a release: goreleaser resolved to `v2.1.0-rc1` rather
+> than the tag that triggered the run, rebuilt the release candidate,
+> and failed uploading assets that were already on the rc1 release. The
+> workflow now pins `GORELEASER_CURRENT_TAG` to the triggering ref, so
+> this cannot recur silently — but the image job derives its tags from
+> the ref independently, and a rehearsal that shares a commit with the
+> real release is confusing to read in the Actions log regardless.
+> Rehearse, then land at least one more commit before tagging.
+
 Watch the run under **Actions**. Confirm all three of:
 
 - the `goreleaser` job uploaded archives, `.deb` and `.rpm` files, and
@@ -165,6 +176,9 @@ git tag -d v2.1.0-rc1
 ```
 
 ### 3. Tag the real release
+
+On a commit *after* the one you rehearsed against — see the warning in
+step 2.
 
 ```sh
 git tag v2.1.0


### PR DESCRIPTION
Fixes the failure that left v2.1.0 half-published.

## What happened

`v2.1.0` was tagged on the same commit as its `v2.1.0-rc1` rehearsal. goreleaser resolves the version from the git history rather than from the ref that started the run, and with two tags on one commit it picked `v2.1.0-rc1`. So the `v2.1.0` run rebuilt the release candidate and died re-uploading assets already attached to the rc1 release:

```
⨯ release failed after 4m12s
  error=scm releases: failed to publish artifacts:
  failed to upload ktunnel_2.1.0-rc1_Windows_x86_64.tar.gz:
  422 Validation Failed [{Resource:ReleaseAsset Field:name Code:already_exists}]
```

Note the filename: `2.1.0-rc1`, on a run triggered by `refs/tags/v2.1.0`.

## What that cost

| Channel | Outcome |
|---|---|
| Docker Hub + ghcr `v2.1.0`, `latest` | ✅ published — the image job derives tags from the ref independently |
| GitHub release `v2.1.0` | ❌ never created |
| Homebrew tap | ❌ still v2.0.2 |
| krew-index | ❌ step never ran, the job had already failed |

Everything goreleaser owns failed; everything it doesn't own succeeded. That split is the tell.

## Fix

`GORELEASER_CURRENT_TAG: ${{ github.ref_name }}` — the triggering ref is the only tag that can be correct for the run.

`RELEASING.md` also gets a warning on the rehearsal step. The env var stops this from failing, but step 2 was telling you to create exactly the ambiguity that caused it, so the guidance now says to rehearse on a throwaway commit and land at least one more commit before tagging the real release.

## After this merges

Delete and re-push `v2.1.0` to re-trigger. Safe: no GitHub release, Homebrew formula or krew entry ever referenced it, and the container images rebuild identically from the same tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)